### PR TITLE
Fix/rsa attribute keysize

### DIFF
--- a/Sources/LibP2PCrypto/Keys/KeyPair.swift
+++ b/Sources/LibP2PCrypto/Keys/KeyPair.swift
@@ -91,7 +91,7 @@ extension LibP2PCrypto.Keys {
                 switch self.publicKey.rawRepresentation.count {
                 case 140, 161, 162:
                     return Attributes(type: .RSA(bits: .B1024), size: 1024, isPrivate: (self.privateKey != nil))
-                case 270, 294:
+                case 270, 293, 294:
                     return Attributes(type: .RSA(bits: .B2048), size: 2048, isPrivate: (self.privateKey != nil))
                 case 398, 422:
                     return Attributes(type: .RSA(bits: .B3072), size: 3072, isPrivate: (self.privateKey != nil))

--- a/Tests/LibP2PCryptoTests/LibP2PCryptoTests.swift
+++ b/Tests/LibP2PCryptoTests/LibP2PCryptoTests.swift
@@ -29,8 +29,6 @@ final class libp2p_cryptoTests: XCTestCase {
         XCTAssertEqual(attributes?.isPrivate, true)
     }
     
-    /// These tests are skipped on Linux when using CryptoSwift due to very slow key generation times.
-    #if canImport(Security)
     func testRSA2048() throws {
         let keyPair = try LibP2PCrypto.Keys.generateKeyPair(.RSA(bits: .B2048))
         print(keyPair)
@@ -45,6 +43,7 @@ final class libp2p_cryptoTests: XCTestCase {
         XCTAssertEqual(attributes?.isPrivate, true)
     }
     
+    /// These tests are skipped on Linux when using CryptoSwift due to very slow key generation times.
     func testRSA3072() throws {
         let keyPair = try LibP2PCrypto.Keys.generateKeyPair(.RSA(bits: .B3072))
         print(keyPair)
@@ -72,8 +71,10 @@ final class libp2p_cryptoTests: XCTestCase {
         XCTAssertEqual(attributes?.size, 4096)
         XCTAssertEqual(attributes?.isPrivate, true)
     }
-  
+    
+    
     /// This test ensures that SecKey's CopyExternalRepresentation outputs the same data as our CryptoSwift RSA Implementation
+    #if canImport(Security)
     func testRSAExternalRepresentation() throws {
         /// Generate a SecKey RSA Key
         let parameters:[CFString:Any] = [

--- a/Tests/LibP2PCryptoTests/LibP2PCryptoTests.swift
+++ b/Tests/LibP2PCryptoTests/LibP2PCryptoTests.swift
@@ -1605,7 +1605,7 @@ final class libp2p_cryptoTests: XCTestCase {
         ("testRSA_Pem_Parsing_Public", testRSA_Pem_Parsing_Public),
         ("testRSA_Pem_Parsing_Private", testRSA_Pem_Parsing_Private),
         ("testEd25519_Pem_Parsing_Public", testEd25519_Pem_Parsing_Public),
-        //("testEd25519_Pem_Parsing_Private", testEd25519_Pem_Parsing_Private),
+        ("testEd25519_Pem_Parsing_Private", testEd25519_Pem_Parsing_Private),
         //("testSecp256k1_Pem_Parsing_Public", testSecp256k1_Pem_Parsing_Public),
         ("testSecp256k1_Pem_Parsing_Private", testSecp256k1_Pem_Parsing_Private),
         ("testEmbeddedEd25519PublicKey", testEmbeddedEd25519PublicKey)


### PR DESCRIPTION
This PR fixes...

- RSA Key size attribute 
- Includes 3072 and 4096 RSA key generation tests on linux