### PR TITLE
Explicitly declaring package names for SwiftProtobuf and secp256k1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,9 +19,9 @@ let package = Package(
         // Multibase Support
         .package(url: "https://github.com/swift-libp2p/swift-multibase.git", .upToNextMinor(from: "0.0.1")),
         // Protobuf Marshaling
-        .package(url: "https://github.com/apple/swift-protobuf.git", .upToNextMajor(from: "1.12.0")),
+        .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf.git", .upToNextMajor(from: "1.12.0")),
         // Secp256k1 Support
-        .package(url: "https://github.com/Boilertalk/secp256k1.swift.git", .exact("0.1.6")),
+        .package(name: "secp256k1", url: "https://github.com/Boilertalk/secp256k1.swift.git", .exact("0.1.6")),
         // 🔑 Hashing (BCrypt, SHA2, HMAC), encryption (AES), public-key (RSA), PEM and DER file handling, and random data generation.
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "1.6.0")),
@@ -35,8 +35,8 @@ let package = Package(
             dependencies: [
                 .product(name: "Multibase", package: "swift-multibase"),
                 .product(name: "Multihash", package: "swift-multihash"),
-                .product(name: "SwiftProtobuf", package: "swift-protobuf"),
-                .product(name: "secp256k1", package: "secp256k1.swift"),
+                .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
+                .product(name: "secp256k1", package: "secp256k1"),
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "CryptoSwift", package: "CryptoSwift"),
             ],

--- a/Sources/LibP2PCrypto/Keys/KeyPair.swift
+++ b/Sources/LibP2PCrypto/Keys/KeyPair.swift
@@ -93,7 +93,7 @@ extension LibP2PCrypto.Keys {
                     return Attributes(type: .RSA(bits: .B1024), size: 1024, isPrivate: (self.privateKey != nil))
                 case 270, 293, 294:
                     return Attributes(type: .RSA(bits: .B2048), size: 2048, isPrivate: (self.privateKey != nil))
-                case 398, 422:
+                case 398, 421, 422:
                     return Attributes(type: .RSA(bits: .B3072), size: 3072, isPrivate: (self.privateKey != nil))
                 case 526, 549, 550, 560:
                     return Attributes(type: .RSA(bits: .B4096), size: 4096, isPrivate: (self.privateKey != nil))

--- a/Sources/LibP2PCrypto/Keys/KeyPair.swift
+++ b/Sources/LibP2PCrypto/Keys/KeyPair.swift
@@ -95,7 +95,7 @@ extension LibP2PCrypto.Keys {
                     return Attributes(type: .RSA(bits: .B2048), size: 2048, isPrivate: (self.privateKey != nil))
                 case 398, 422:
                     return Attributes(type: .RSA(bits: .B3072), size: 3072, isPrivate: (self.privateKey != nil))
-                case 526, 550, 560:
+                case 526, 549, 550, 560:
                     return Attributes(type: .RSA(bits: .B4096), size: 4096, isPrivate: (self.privateKey != nil))
                 default:
                     print("PubKey Data Count: \(count)");


### PR DESCRIPTION
This PR...

Fixes: 
- When using Swift 5.4 (and SPM 5.4) we receive a Package resolution error stating the product SwiftProtobuf can't be found in the package `swift-protobuf` (and similarly with the `secp256k1` package).
- This issue happens when packages specify a different Package.name property compared to the GitHub repo name.

By:
- Explicitly declares the SwiftProtobuf package name in the Package.swift file
- Explicitly declares the secp256k1 package name in the Package.swift file


