### PR TITLE
Misc Fixes

### DIFF
--- a/Sources/LibP2PCrypto/AES/AES.swift
+++ b/Sources/LibP2PCrypto/AES/AES.swift
@@ -43,11 +43,11 @@ extension LibP2PCrypto {
 
             public init(key: Data, iv: Data) throws {
                 guard key.count == kCCKeySizeAES128 || key.count == kCCKeySizeAES256 else {
-                    throw NSError(domain: "Error: Failed to set a key.", code: 0, userInfo: nil)
+                    throw LibP2PCrypto.Keys.KeyError.invalidParameters("AES: invalid key")
                 }
 
                 guard iv.count == kCCBlockSizeAES128 else {
-                    throw NSError(domain: "Error: Failed to set an initial vector.", code: 0, userInfo: nil)
+                    throw LibP2PCrypto.Keys.KeyError.invalidParameters("AES: invalid initial vector")
                 }
                 self.key = key
                 self.iv = iv
@@ -60,7 +60,7 @@ extension LibP2PCrypto {
             /// - Throws: An error if one is encountered along the way
             public init(key: String, iv: String) throws {
                 guard let keyData = key.data(using: .utf8), let ivData = iv.data(using: .utf8) else {
-                    throw NSError(domain: "Error: Failed to set a key.", code: 0, userInfo: nil)
+                    throw LibP2PCrypto.Keys.KeyError.invalidParameters("AES: invalid key")
                 }
 
                 self.key = keyData
@@ -74,7 +74,7 @@ extension LibP2PCrypto {
                 guard key.count == kCCKeySizeAES128 || key.count == kCCKeySizeAES256,
                     let keyData = key.data(using: .utf8)
                 else {
-                    throw NSError(domain: "Error: Failed to set a key.", code: 0, userInfo: nil)
+                    throw LibP2PCrypto.Keys.KeyError.invalidParameters("AES: invalid key")
                 }
                 try self.init(key: keyData, iv: Data(LibP2PCrypto.randomBytes(length: 16)))
             }
@@ -155,7 +155,7 @@ extension LibP2PCrypto {
                 }
 
                 guard UInt32(status) == UInt32(kCCSuccess) else {
-                    throw NSError(domain: "Error: Failed to crypt data. Status \(status)", code: 0, userInfo: nil)
+                    throw LibP2PCrypto.Keys.KeyError.internalError("AES: CCCrypt failed with status \(status)")
                 }
 
                 cryptData.removeSubrange(bytesLength..<cryptData.count)
@@ -195,11 +195,11 @@ extension LibP2PCrypto {
             public init(key: Data, iv: Data) throws {
 
                 guard key.count == 16 || key.count == 32 else {
-                    throw NSError(domain: "Error: Failed to set a key.", code: 0, userInfo: nil)
+                    throw LibP2PCrypto.Keys.KeyError.invalidParameters("AES: invalid key")
                 }
 
                 guard iv.count == 16 else {
-                    throw NSError(domain: "Error: Failed to set an initial vector.", code: 0, userInfo: nil)
+                    throw LibP2PCrypto.Keys.KeyError.invalidParameters("AES: invalid initial vector")
                 }
 
                 self.aes = try CryptoSwift.AES(key: key.byteArray, blockMode: CBC(iv: iv.byteArray), padding: .pkcs5)
@@ -212,7 +212,7 @@ extension LibP2PCrypto {
             /// - Throws: An error if one is encountered along the way
             public init(key: String, iv: String) throws {
                 guard let keyData = key.data(using: .utf8), let ivData = iv.data(using: .utf8) else {
-                    throw NSError(domain: "Error: Failed to set a key.", code: 0, userInfo: nil)
+                    throw LibP2PCrypto.Keys.KeyError.invalidParameters("AES: invalid key")
                 }
 
                 try self.init(key: keyData, iv: ivData)
@@ -223,7 +223,7 @@ extension LibP2PCrypto {
             /// - Throws: An error if one is encountered along the way
             public init(key: String) throws {
                 guard key.count == 16 || key.count == 32, let keyData = key.data(using: .utf8) else {
-                    throw NSError(domain: "Error: Failed to set a key.", code: 0, userInfo: nil)
+                    throw LibP2PCrypto.Keys.KeyError.invalidParameters("AES: invalid key")
                 }
 
                 try self.init(key: keyData, iv: Data(LibP2PCrypto.randomBytes(length: 16)))

--- a/Sources/LibP2PCrypto/HMAC/HMAC.swift
+++ b/Sources/LibP2PCrypto/HMAC/HMAC.swift
@@ -123,7 +123,7 @@ extension Encryptable {
     /// A default string -> data implementation using .utf8 encoding...
     public func encrypt(_ message: String, encodedUsing encoding: String.Encoding = .utf8) throws -> Data {
         guard let d = message.data(using: encoding) else {
-            throw NSError(domain: "Error: Failed to encode string using \(encoding).", code: 0, userInfo: nil)
+            throw LibP2PCrypto.Keys.KeyError.invalidParameters("Failed to encode string using \(encoding)")
         }
         return try self.encrypt(d)
     }
@@ -156,7 +156,7 @@ extension Decryptable {
     public func decrypt(_ data: Data, intoString encoding: String.Encoding = .utf8) throws -> String {
         let d = try self.decrypt(data)
         guard let str = String(data: d, encoding: encoding) else {
-            throw NSError(domain: "Error: Failed to encode data using \(encoding).", code: 0, userInfo: nil)
+            throw LibP2PCrypto.Keys.KeyError.invalidParameters("Failed to decode data using \(encoding)")
         }
         return str
     }
@@ -164,7 +164,7 @@ extension Decryptable {
     public func decrypt(_ bytes: [UInt8], intoString encoding: String.Encoding = .utf8) throws -> String {
         let d = try self.decrypt(bytes)
         guard let str = String(data: d, encoding: encoding) else {
-            throw NSError(domain: "Error: Failed to encode data using \(encoding).", code: 0, userInfo: nil)
+            throw LibP2PCrypto.Keys.KeyError.invalidParameters("Failed to decode data using \(encoding)")
         }
         return str
     }
@@ -176,7 +176,7 @@ extension Decryptable {
     ) throws -> String {
         let d = try self.decrypt(baseEncoded: baseEncoded, base: base)
         guard let str = String(data: d, encoding: encoding) else {
-            throw NSError(domain: "Error: Failed to encode data using \(encoding).", code: 0, userInfo: nil)
+            throw LibP2PCrypto.Keys.KeyError.invalidParameters("Failed to decode data using \(encoding)")
         }
         return str
     }
@@ -184,7 +184,7 @@ extension Decryptable {
     public func decrypt(multibaseEncoded: String, intoString encoding: String.Encoding = .utf8) throws -> String {
         let d = try self.decrypt(multibaseEncoded: multibaseEncoded)
         guard let str = String(data: d, encoding: encoding) else {
-            throw NSError(domain: "Error: Failed to encode data using \(encoding).", code: 0, userInfo: nil)
+            throw LibP2PCrypto.Keys.KeyError.invalidParameters("Failed to decode data using \(encoding)")
         }
         return str
     }

--- a/Sources/LibP2PCrypto/Keys/KeyError.swift
+++ b/Sources/LibP2PCrypto/Keys/KeyError.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-libp2p open source project
+//
+// Copyright (c) 2022-2025 swift-libp2p project authors
+// Licensed under MIT
+//
+// See LICENSE for license information
+// See CONTRIBUTORS for the list of swift-libp2p project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+extension LibP2PCrypto.Keys {
+    /// The errors that can be thrown by the key subsystem.
+    ///
+    /// This replaces the ad-hoc `NSError(domain:code:)` values that were previously thrown
+    /// throughout the library. Prefer matching on a specific case over inspecting the
+    /// human-readable `description`.
+    public enum KeyError: Swift.Error, CustomStringConvertible, Sendable, Equatable {
+        /// An operation that requires a private key was attempted on a public-only `KeyPair`.
+        case noPrivateKey
+        /// The requested key type isn't supported (by this platform or at all).
+        case unsupportedKeyType(String)
+        /// The key type doesn't support the requested operation (e.g. Secp256k1 encryption).
+        case unsupportedOperation(String)
+        /// The provided raw key bytes couldn't be interpreted as a valid key.
+        case invalidRawRepresentation(String)
+        /// The protobuf-marshaled key data was malformed or of the wrong type.
+        case invalidMarshaledData(String)
+        /// A private key's on-the-wire encoding failed validation (e.g. mismatched public key).
+        case invalidPrivateKeyEncoding(String)
+        /// Key generation failed in the underlying crypto provider.
+        case keyGenerationFailed(String)
+        /// Deriving a public key from a private key failed.
+        case publicKeyDerivationFailed(String)
+        /// Encryption failed in the underlying crypto provider.
+        case encryptionFailed(String)
+        /// Decryption failed in the underlying crypto provider.
+        case decryptionFailed(String)
+        /// Producing a signature failed.
+        case signatureFailed(String)
+        /// A signature was the wrong length for the key type.
+        case invalidSignatureLength(expected: Int, got: Int)
+        /// The caller passed invalid or inconsistent parameters.
+        case invalidParameters(String)
+        /// An unexpected internal failure. The associated value describes the context.
+        case internalError(String)
+
+        public var description: String {
+            switch self {
+            case .noPrivateKey:
+                return "No private key available for this operation."
+            case .unsupportedKeyType(let detail):
+                return "Unsupported key type: \(detail)"
+            case .unsupportedOperation(let detail):
+                return "Unsupported operation: \(detail)"
+            case .invalidRawRepresentation(let detail):
+                return "Invalid raw key representation: \(detail)"
+            case .invalidMarshaledData(let detail):
+                return "Invalid marshaled key data: \(detail)"
+            case .invalidPrivateKeyEncoding(let detail):
+                return "Invalid private key encoding: \(detail)"
+            case .keyGenerationFailed(let detail):
+                return "Key generation failed: \(detail)"
+            case .publicKeyDerivationFailed(let detail):
+                return "Public key derivation failed: \(detail)"
+            case .encryptionFailed(let detail):
+                return "Encryption failed: \(detail)"
+            case .decryptionFailed(let detail):
+                return "Decryption failed: \(detail)"
+            case .signatureFailed(let detail):
+                return "Signature failed: \(detail)"
+            case .invalidSignatureLength(let expected, let got):
+                return "Invalid signature length, expected at least \(expected) bytes, got \(got)."
+            case .invalidParameters(let detail):
+                return "Invalid parameters: \(detail)"
+            case .internalError(let detail):
+                return "Internal error: \(detail)"
+            }
+        }
+    }
+}

--- a/Sources/LibP2PCrypto/Keys/KeyPair.swift
+++ b/Sources/LibP2PCrypto/Keys/KeyPair.swift
@@ -118,7 +118,8 @@ extension LibP2PCrypto.Keys {
             }
         }
 
-        /// Extracts the RSA modulus bit-length from the public key's SubjectPublicKeyInfo DER.
+        /// Extracts the RSA modulus size (in bits, rounded up to a whole byte) from the
+        /// public key's SubjectPublicKeyInfo DER.
         ///
         /// Returns `nil` if the key isn't RSA or the DER can't be parsed as expected.
         private func rsaModulusBitCount() -> Int? {
@@ -130,11 +131,15 @@ extension LibP2PCrypto.Keys {
                 case .sequence(let numbers)? = try? ASN1.Decoder.decode(data: pkcs1),
                 case .integer(let modulus)? = numbers.first
             else { return nil }
-            // Strip DER sign-padding / leading zero bytes, then measure the remaining bits.
+            // Strip the DER sign byte / leading-zero padding, then report the modulus size
+            // rounded up to a whole byte. Some backends (notably CryptoSwift on Linux)
+            // occasionally emit a modulus whose top bit is clear, making the exact bit-count
+            // one short (e.g. 2047 for a 2048-bit key); byte-aligning classifies these the
+            // same as a fully-populated modulus of the same key size.
             var bytes = modulus.byteArray
             while bytes.first == 0 { bytes.removeFirst() }
-            guard let msb = bytes.first else { return nil }
-            return bytes.count * 8 - msb.leadingZeroBitCount
+            guard bytes.isEmpty == false else { return nil }
+            return bytes.count * 8
         }
 
         //public func asString(base:BaseEncoding, withMultibasePrefix:Bool = false) -> String {

--- a/Sources/LibP2PCrypto/Keys/KeyPair.swift
+++ b/Sources/LibP2PCrypto/Keys/KeyPair.swift
@@ -448,11 +448,7 @@ extension LibP2PCrypto.Keys.KeyPair {
     }
 
     public func exportEncryptedPrivatePEMString(withPassword password: String) throws -> String {
-        try self.exportEncryptedPrivatePEMString(
-            withPassword: password,
-            usingPBKDF: .pbkdf2(salt: LibP2PCrypto.randomBytes(length: 8), iterations: 2048),
-            andCipher: .aes_128_cbc(iv: LibP2PCrypto.randomBytes(length: 16))
-        )
+        try self.exportEncryptedPrivatePEMString(withPassword: password, usingPBKDF: nil, andCipher: nil)
     }
 
     internal func exportEncryptedPrivatePEM(
@@ -460,11 +456,12 @@ extension LibP2PCrypto.Keys.KeyPair {
         usingPBKDF pbkdf: LibP2PCrypto.PEM.PBKDFAlgorithm? = nil,
         andCipher cipher: LibP2PCrypto.PEM.CipherAlgorithm? = nil
     ) throws -> [UInt8] {
-        let cipher = try cipher ?? .aes_128_cbc(iv: LibP2PCrypto.randomBytes(length: 16))
-        let pbkdf = try pbkdf ?? .pbkdf2(salt: LibP2PCrypto.randomBytes(length: 8), iterations: 2048)
+        guard let privateKey = self.privateKey else {
+            throw LibP2PCrypto.Keys.KeyError.noPrivateKey
+        }
 
         return try LibP2PCrypto.PEM.encryptPEM(
-            Data(self.privateKey!.exportPrivateKeyPEMRaw()),
+            Data(privateKey.exportPrivateKeyPEMRaw()),
             withPassword: password,
             usingPBKDF: pbkdf,
             andCipher: cipher
@@ -477,7 +474,10 @@ extension LibP2PCrypto.Keys.KeyPair {
         andCipher cipher: LibP2PCrypto.PEM.CipherAlgorithm? = nil
     ) throws -> String {
         let data = try self.exportEncryptedPrivatePEM(withPassword: password, usingPBKDF: pbkdf, andCipher: cipher)
-        return String(data: Data(data), encoding: .utf8)!
+        guard let string = String(data: Data(data), encoding: .utf8) else {
+            throw LibP2PCrypto.PEM.Error.encodingError
+        }
+        return string
     }
 
 }

--- a/Sources/LibP2PCrypto/Keys/KeyPair.swift
+++ b/Sources/LibP2PCrypto/Keys/KeyPair.swift
@@ -63,7 +63,8 @@ extension LibP2PCrypto.Keys {
             self.privateKey = nil
         }
 
-        var hasPrivateKey: Bool {
+        /// Whether this `KeyPair` carries a private key (and can therefore sign / decrypt).
+        public var hasPrivateKey: Bool {
             privateKey != nil
         }
 

--- a/Sources/LibP2PCrypto/Keys/KeyPair.swift
+++ b/Sources/LibP2PCrypto/Keys/KeyPair.swift
@@ -92,29 +92,29 @@ extension LibP2PCrypto.Keys {
         }
 
         /// Misc KeyPair Attributes (type, size, isPrivate)
+        ///
+        /// For RSA keys the size is derived from the actual modulus bit-length rather than a
+        /// table of expected DER byte-counts, so non-standard key sizes are reported correctly.
         public func attributes() -> Attributes? {
+            let isPrivate = self.privateKey != nil
             switch self.keyType {
             case .rsa:
-                let count = self.publicKey.rawRepresentation.count
-                switch self.publicKey.rawRepresentation.count {
-                case 140, 161, 162:
-                    return Attributes(type: .RSA(bits: .B1024), size: 1024, isPrivate: (self.privateKey != nil))
-                case 270, 293, 294:
-                    return Attributes(type: .RSA(bits: .B2048), size: 2048, isPrivate: (self.privateKey != nil))
-                case 398, 421, 422:
-                    return Attributes(type: .RSA(bits: .B3072), size: 3072, isPrivate: (self.privateKey != nil))
-                case 526, 549, 550, 560:
-                    return Attributes(type: .RSA(bits: .B4096), size: 4096, isPrivate: (self.privateKey != nil))
-                default:
-                    print("PubKey Data Count: \(count)")
-                    return nil
+                guard let bits = rsaModulusBitCount() else { return nil }
+                let type: LibP2PCrypto.Keys.KeyPairType
+                switch bits {
+                case 1024: type = .RSA(bits: .B1024)
+                case 2048: type = .RSA(bits: .B2048)
+                case 3072: type = .RSA(bits: .B3072)
+                case 4096: type = .RSA(bits: .B4096)
+                default: type = .RSA(bits: .custom(bits: bits))
                 }
+                return Attributes(type: type, size: bits, isPrivate: isPrivate)
 
             case .ed25519:
-                return Attributes(type: .Ed25519, size: 32, isPrivate: (self.privateKey != nil))
+                return Attributes(type: .Ed25519, size: 32, isPrivate: isPrivate)
 
             case .secp256k1:
-                return Attributes(type: .Secp256k1, size: 64, isPrivate: (self.privateKey != nil))
+                return Attributes(type: .Secp256k1, size: 64, isPrivate: isPrivate)
             }
         }
 

--- a/Sources/LibP2PCrypto/Keys/KeyPair.swift
+++ b/Sources/LibP2PCrypto/Keys/KeyPair.swift
@@ -131,7 +131,7 @@ extension LibP2PCrypto.Keys {
         /// Certain asymmetric keys support decrypting data, use this method to decrypt previously encrypted data.
         func decrypt(data: Data) throws -> Data {
             guard let privateKey = privateKey else {
-                throw NSError(domain: "Can't decrypt data without a private key", code: 0)
+                throw LibP2PCrypto.Keys.KeyError.noPrivateKey
             }
             return try privateKey.decrypt(data: data)
         }
@@ -143,7 +143,7 @@ extension LibP2PCrypto.Keys {
         /// - Note: Verify this signature by using the PublicKey and calling `.verify(signature:Data, for:Data) throws -> Bool`
         func sign(message data: Data) throws -> Data {
             guard let privateKey = privateKey else {
-                throw NSError(domain: "Can't sign data without a private key", code: 0)
+                throw LibP2PCrypto.Keys.KeyError.noPrivateKey
             }
             return try privateKey.sign(message: data)
         }
@@ -196,9 +196,8 @@ extension LibP2PCrypto.Keys {
                     // Ensure we can derive the attached public key
                     let privkey = try Curve25519.Signing.PrivateKey(marshaledData: proto.data.prefix(32))
                     guard privkey.publicKey.rawRepresentation == proto.data.suffix(32) else {
-                        throw NSError(
-                            domain: "Invalid private key protobuf encoding -> unable to validate public key",
-                            code: 0
+                        throw LibP2PCrypto.Keys.KeyError.invalidPrivateKeyEncoding(
+                            "Ed25519: unable to validate attached public key"
                         )
                     }
                     try self.init(privateKey: privkey)
@@ -207,18 +206,21 @@ extension LibP2PCrypto.Keys {
                     // Ensure the two pubkeys match and we can derive the attached public key
                     let parts = Array(proto.data.chunks(ofCount: 32))
                     guard parts[1] == parts[2] else {
-                        throw NSError(domain: "Invalid private key protobuf encoding -> pubkeys dont match", code: 0)
+                        throw LibP2PCrypto.Keys.KeyError.invalidPrivateKeyEncoding(
+                            "Ed25519: attached public keys don't match"
+                        )
                     }
                     let privkey = try Curve25519.Signing.PrivateKey(marshaledData: parts[0])
                     guard privkey.publicKey.rawRepresentation == parts[1] else {
-                        throw NSError(
-                            domain: "Invalid private key protobuf encoding -> unable to validate public key",
-                            code: 0
+                        throw LibP2PCrypto.Keys.KeyError.invalidPrivateKeyEncoding(
+                            "Ed25519: unable to validate attached public key"
                         )
                     }
                     try self.init(privateKey: privkey)
                 default:
-                    throw NSError(domain: "Invalid private key protobuf encoding -> invalid data payload", code: 0)
+                    throw LibP2PCrypto.Keys.KeyError.invalidPrivateKeyEncoding(
+                        "Ed25519: invalid data payload length \(proto.data.count)"
+                    )
                 }
             case .secp256K1:
                 try self.init(privateKey: Secp256k1PrivateKey(marshaledData: proto.data))
@@ -403,7 +405,7 @@ extension LibP2PCrypto.Keys.KeyPair {
 
     public func exportPrivatePEM(withHeaderAndFooter: Bool = true) throws -> [UInt8] {
         guard let privKey = self.privateKey else {
-            throw NSError(domain: "No private key available to export", code: 0)
+            throw LibP2PCrypto.Keys.KeyError.noPrivateKey
         }
         //guard let der = privKey as? DEREncodable else { throw NSError(domain: "Unknown private key type", code: 0) }
         return try privKey.exportPrivateKeyPEM(withHeaderAndFooter: withHeaderAndFooter)
@@ -416,7 +418,7 @@ extension LibP2PCrypto.Keys.KeyPair {
 
     public func exportPrivatePEMString(withHeaderAndFooter: Bool = true) throws -> String {
         guard let privKey = self.privateKey else {
-            throw NSError(domain: "No private key available to export", code: 0)
+            throw LibP2PCrypto.Keys.KeyError.noPrivateKey
         }
         //guard let der = privKey as? DEREncodable else { throw NSError(domain: "Unknown private key type", code: 0) }
         return try privKey.exportPrivateKeyPEMString(withHeaderAndFooter: withHeaderAndFooter)

--- a/Sources/LibP2PCrypto/Keys/KeyPair.swift
+++ b/Sources/LibP2PCrypto/Keys/KeyPair.swift
@@ -144,12 +144,12 @@ extension LibP2PCrypto.Keys {
         // - MARK: Encryption & Decryption
 
         /// Certain asymmetric keys support encrypting data, use this method to do so.
-        func encrypt(data: Data) throws -> Data {
+        public func encrypt(data: Data) throws -> Data {
             try self.publicKey.encrypt(data: data)
         }
 
         /// Certain asymmetric keys support decrypting data, use this method to decrypt previously encrypted data.
-        func decrypt(data: Data) throws -> Data {
+        public func decrypt(data: Data) throws -> Data {
             guard let privateKey = privateKey else {
                 throw LibP2PCrypto.Keys.KeyError.noPrivateKey
             }
@@ -158,18 +158,19 @@ extension LibP2PCrypto.Keys {
 
         // - MARK: Signature & Verifications
 
-        /// Sign a peice of data for verification by another peer
+        /// Sign a piece of data for verification by another peer.
         ///
-        /// - Note: Verify this signature by using the PublicKey and calling `.verify(signature:Data, for:Data) throws -> Bool`
-        func sign(message data: Data) throws -> Data {
+        /// - Note: Verify this signature by using the public key and calling
+        ///   `verify(signature:for:)`.
+        public func sign(message data: Data) throws -> Data {
             guard let privateKey = privateKey else {
                 throw LibP2PCrypto.Keys.KeyError.noPrivateKey
             }
             return try privateKey.sign(message: data)
         }
 
-        /// Verify a signature for the expected data
-        func verify(signature: Data, for data: Data) throws -> Bool {
+        /// Verify a signature for the expected data.
+        public func verify(signature: Data, for data: Data) throws -> Bool {
             try self.publicKey.verify(signature: signature, for: data)
         }
 
@@ -249,16 +250,21 @@ extension LibP2PCrypto.Keys {
 
         // - MARK: Exports
 
-        func marshalPublicKey() throws -> Data {
+        /// The protobuf-marshaled representation of the public key
+        /// (see the [libp2p peer-id spec](https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md)).
+        public func marshalPublicKey() throws -> Data {
             try publicKey.marshal()
         }
 
-        //func marshalPrivateKey() throws -> Data {
-        //    guard let privateKey = privateKey else {
-        //        throw NSError(domain: "No Private Key", code: 0)
-        //    }
-        //    return try privateKey.marshal()
-        //}
+        /// The protobuf-marshaled representation of the private key.
+        ///
+        /// - Throws: ``LibP2PCrypto/Keys/KeyError/noPrivateKey`` if this `KeyPair` only holds a public key.
+        public func marshalPrivateKey() throws -> Data {
+            guard let privateKey = privateKey else {
+                throw LibP2PCrypto.Keys.KeyError.noPrivateKey
+            }
+            return try privateKey.marshal()
+        }
 
     }
 }

--- a/Sources/LibP2PCrypto/Keys/KeyPair.swift
+++ b/Sources/LibP2PCrypto/Keys/KeyPair.swift
@@ -118,6 +118,25 @@ extension LibP2PCrypto.Keys {
             }
         }
 
+        /// Extracts the RSA modulus bit-length from the public key's SubjectPublicKeyInfo DER.
+        ///
+        /// Returns `nil` if the key isn't RSA or the DER can't be parsed as expected.
+        private func rsaModulusBitCount() -> Int? {
+            guard case .rsa = self.keyType else { return nil }
+            guard
+                case .sequence(let top)? = try? ASN1.Decoder.decode(data: self.publicKey.rawRepresentation),
+                top.count >= 2,
+                case .bitString(let pkcs1) = top[1],
+                case .sequence(let numbers)? = try? ASN1.Decoder.decode(data: pkcs1),
+                case .integer(let modulus)? = numbers.first
+            else { return nil }
+            // Strip DER sign-padding / leading zero bytes, then measure the remaining bits.
+            var bytes = modulus.byteArray
+            while bytes.first == 0 { bytes.removeFirst() }
+            guard let msb = bytes.first else { return nil }
+            return bytes.count * 8 - msb.leadingZeroBitCount
+        }
+
         //public func asString(base:BaseEncoding, withMultibasePrefix:Bool = false) -> String {
         //    self.data.asString(base: base, withMultibasePrefix: withMultibasePrefix)
         //}

--- a/Sources/LibP2PCrypto/Keys/KeyPair.swift
+++ b/Sources/LibP2PCrypto/Keys/KeyPair.swift
@@ -415,7 +415,6 @@ extension LibP2PCrypto.Keys.KeyPair {
                 )
                 try self.init(privateKey: Secp256k1PrivateKey(privateDER: der))
             } else {
-                print(ids)
                 throw LibP2PCrypto.PEM.Error.unsupportedPEMType
             }
         }
@@ -433,7 +432,6 @@ extension LibP2PCrypto.Keys.KeyPair {
         guard let privKey = self.privateKey else {
             throw LibP2PCrypto.Keys.KeyError.noPrivateKey
         }
-        //guard let der = privKey as? DEREncodable else { throw NSError(domain: "Unknown private key type", code: 0) }
         return try privKey.exportPrivateKeyPEM(withHeaderAndFooter: withHeaderAndFooter)
     }
 
@@ -446,7 +444,6 @@ extension LibP2PCrypto.Keys.KeyPair {
         guard let privKey = self.privateKey else {
             throw LibP2PCrypto.Keys.KeyError.noPrivateKey
         }
-        //guard let der = privKey as? DEREncodable else { throw NSError(domain: "Unknown private key type", code: 0) }
         return try privKey.exportPrivateKeyPEMString(withHeaderAndFooter: withHeaderAndFooter)
     }
 

--- a/Sources/LibP2PCrypto/Keys/Keys.swift
+++ b/Sources/LibP2PCrypto/Keys/Keys.swift
@@ -126,6 +126,17 @@ extension LibP2PCrypto {
             try LibP2PCrypto.Keys.KeyPair(type)
         }
 
+        /// Asynchronously generates a new key pair off the calling thread.
+        ///
+        /// Prefer this over the synchronous initializer for large RSA keys (3072 / 4096 bit),
+        /// where generation can take a noticeable amount of time and would otherwise block the
+        /// current task/actor.
+        public static func generateKeyPair(_ type: KeyPairType) async throws -> KeyPair {
+            try await Task.detached(priority: .userInitiated) {
+                try LibP2PCrypto.Keys.KeyPair(type)
+            }.value
+        }
+
         /// Converts a protobuf serialized public key into its representative object.
         public static func unmarshalPublicKey(buf: [UInt8], into base: BaseEncoding = .base16) throws -> String {
             let pubKeyProto = try PublicKey(serializedBytes: buf)

--- a/Sources/LibP2PCrypto/Keys/Keys.swift
+++ b/Sources/LibP2PCrypto/Keys/Keys.swift
@@ -131,7 +131,7 @@ extension LibP2PCrypto {
             let pubKeyProto = try PublicKey(serializedBytes: buf)
 
             guard !pubKeyProto.data.isEmpty else {
-                throw NSError(domain: "Unable to Unmarshal PublicKey", code: 0, userInfo: nil)
+                throw KeyError.invalidMarshaledData("Public key payload was empty")
             }
             switch pubKeyProto.type {
             case .rsa:
@@ -162,11 +162,8 @@ extension LibP2PCrypto {
                 }
                 return try self.marshalPrivateKey(raw: decoded.data, keyType: asKeyType)
             } catch {
-                print(error)
-                throw NSError(
-                    domain: "Failed to decode raw private key, unknown base encoding.",
-                    code: 0,
-                    userInfo: nil
+                throw KeyError.invalidParameters(
+                    "Failed to decode raw private key, unknown base encoding: \(error)"
                 )
             }
         }
@@ -183,7 +180,7 @@ extension LibP2PCrypto {
             let privKeyProto = try PrivateKey(serializedBytes: buf)
 
             let data = privKeyProto.data
-            guard !data.isEmpty else { throw NSError(domain: "Unable to Unmarshal PrivateKey", code: 0, userInfo: nil) }
+            guard !data.isEmpty else { throw KeyError.invalidMarshaledData("Private key payload was empty") }
 
             return data.asString(base: base)
         }

--- a/Sources/LibP2PCrypto/Keys/Types/Ed25519/Ed25519.swift
+++ b/Sources/LibP2PCrypto/Keys/Types/Ed25519/Ed25519.swift
@@ -23,7 +23,7 @@ extension Curve25519.Signing.PublicKey: CommonPublicKey, @unchecked Sendable {
     }
 
     public func encrypt(data: Data) throws -> Data {
-        throw NSError(domain: "Ed25519 Keys don't support encryption", code: 0)
+        throw LibP2PCrypto.Keys.KeyError.unsupportedOperation("Ed25519 keys don't support encryption")
     }
 
     public func verify(signature: Data, for expectedData: Data) throws -> Bool {
@@ -50,7 +50,7 @@ extension Curve25519.Signing.PrivateKey: CommonPrivateKey, @unchecked Sendable {
     }
 
     public func decrypt(data: Data) throws -> Data {
-        throw NSError(domain: "ED25519 keys don't support decryption", code: 0)
+        throw LibP2PCrypto.Keys.KeyError.unsupportedOperation("Ed25519 keys don't support decryption")
     }
 
     public func sign(message data: Data) throws -> Data {
@@ -86,7 +86,9 @@ extension Curve25519.Signing.PublicKey: DERCodable {
     }
 
     public init(privateDER: [UInt8]) throws {
-        throw NSError(domain: "Can't instantiate private key from public DER representation", code: 0)
+        throw LibP2PCrypto.Keys.KeyError.unsupportedOperation(
+            "Can't instantiate a public key from a private DER representation"
+        )
     }
 
     public func publicKeyDER() throws -> [UInt8] {
@@ -94,7 +96,7 @@ extension Curve25519.Signing.PublicKey: DERCodable {
     }
 
     public func privateKeyDER() throws -> [UInt8] {
-        throw NSError(domain: "Public Key doesn't have private DER representation", code: 0)
+        throw LibP2PCrypto.Keys.KeyError.unsupportedOperation("A public key has no private DER representation")
     }
 
     public func exportPublicKeyPEM(withHeaderAndFooter: Bool) throws -> [UInt8] {
@@ -127,7 +129,9 @@ extension Curve25519.Signing.PrivateKey: DERCodable {
     public static var secondaryObjectIdentifier: [UInt8]? { nil }
 
     public init(publicDER: [UInt8]) throws {
-        throw NSError(domain: "Can't instantiate private key from public DER representation", code: 0)
+        throw LibP2PCrypto.Keys.KeyError.unsupportedOperation(
+            "Can't instantiate a private key from a public DER representation"
+        )
     }
 
     public init(privateDER: [UInt8]) throws {

--- a/Sources/LibP2PCrypto/Keys/Types/RSA/RSA+CryptoSwift.swift
+++ b/Sources/LibP2PCrypto/Keys/Types/RSA/RSA+CryptoSwift.swift
@@ -48,7 +48,9 @@ struct RSAPublicKey: CommonPublicKey {
                 throw LibP2PCrypto.Keys.KeyError.invalidRawRepresentation("RSA public key: missing object identifier")
             }
             guard oid.byteArray == RSAPublicKey.RSA_OBJECT_IDENTIFIER else {
-                throw LibP2PCrypto.Keys.KeyError.invalidRawRepresentation("RSA public key: unexpected object identifier")
+                throw LibP2PCrypto.Keys.KeyError.invalidRawRepresentation(
+                    "RSA public key: unexpected object identifier"
+                )
             }
             guard case .bitString(let bits) = params.last else {
                 throw LibP2PCrypto.Keys.KeyError.invalidRawRepresentation("RSA public key: missing key bit string")

--- a/Sources/LibP2PCrypto/Keys/Types/RSA/RSA+CryptoSwift.swift
+++ b/Sources/LibP2PCrypto/Keys/Types/RSA/RSA+CryptoSwift.swift
@@ -33,19 +33,19 @@ struct RSAPublicKey: CommonPublicKey {
         let asn1 = try ASN1.Decoder.decode(data: raw)
 
         guard case .sequence(let params) = asn1 else {
-            throw NSError(domain: "Invalid ASN1 Encoding -> \(asn1)", code: 0)
+            throw LibP2PCrypto.Keys.KeyError.invalidRawRepresentation("RSA public key: not an ASN.1 sequence")
         }
 
         /// We have an objectID header....
         if case .sequence(let objectID) = params.first {
             guard case .objectIdentifier(let oid) = objectID.first else {
-                throw NSError(domain: "Invalid ASN1 Encoding -> No ObjectID", code: 0)
+                throw LibP2PCrypto.Keys.KeyError.invalidRawRepresentation("RSA public key: missing object identifier")
             }
             guard oid.byteArray == RSAPublicKey.RSA_OBJECT_IDENTIFIER else {
-                throw NSError(domain: "Invalid ASN1 Encoding -> ObjectID != Public RSA Key ID", code: 0)
+                throw LibP2PCrypto.Keys.KeyError.invalidRawRepresentation("RSA public key: unexpected object identifier")
             }
             guard case .bitString(let bits) = params.last else {
-                throw NSError(domain: "Invalid ASN1 Encoding -> No BitString", code: 0)
+                throw LibP2PCrypto.Keys.KeyError.invalidRawRepresentation("RSA public key: missing key bit string")
             }
 
             self.key = try CryptoSwift.RSA(rawRepresentation: bits)
@@ -60,7 +60,7 @@ struct RSAPublicKey: CommonPublicKey {
 
             self.key = CryptoSwift.RSA(n: n.byteArray, e: e.byteArray)
         } else {
-            throw NSError(domain: "Invalid RSA rawRepresentation", code: 0)
+            throw LibP2PCrypto.Keys.KeyError.invalidRawRepresentation("RSA public key: unrecognized structure")
         }
     }
 
@@ -90,7 +90,7 @@ struct RSAPublicKey: CommonPublicKey {
     /// - Note: We throw on false to match the SecKey implementation
     func verify(signature: Data, for expectedData: Data) throws -> Bool {
         guard try RSA.verify(signature: signature, fromMessage: expectedData, usingKey: self.key) else {
-            throw NSError(domain: "Invalid signature for expected data", code: 0)
+            throw LibP2PCrypto.Keys.KeyError.signatureFailed("RSA: invalid signature for expected data")
         }
         return true
     }
@@ -126,7 +126,9 @@ struct RSAPrivateKey: CommonPrivateKey {
         case 4096:
             self.key = try CryptoSwift.RSA(keySize: keySize)
         default:
-            throw NSError(domain: "Invalid RSA Key Bit Length. (Use one of 2048, 3072 or 4096)", code: 0)
+            throw LibP2PCrypto.Keys.KeyError.invalidParameters(
+                "Invalid RSA key bit length (use 2048, 3072 or 4096), got \(keySize)"
+            )
         }
     }
 

--- a/Sources/LibP2PCrypto/Keys/Types/RSA/RSA+CryptoSwift.swift
+++ b/Sources/LibP2PCrypto/Keys/Types/RSA/RSA+CryptoSwift.swift
@@ -25,8 +25,13 @@ struct RSAPublicKey: CommonPublicKey {
     /// The underlying CryptoSwift RSA Key that backs this struct
     private let key: RSA
 
-    fileprivate init(_ rsa: RSA) {
+    /// The PKCS#1 DER (`externalRepresentation()`) captured at init time so that the
+    /// non-throwing `rawRepresentation` accessor can never crash or silently return empty data.
+    private let externalRepresentationBytes: Data
+
+    fileprivate init(_ rsa: RSA) throws {
         self.key = rsa
+        self.externalRepresentationBytes = try rsa.externalRepresentation()
     }
 
     init(rawRepresentation raw: Data) throws {
@@ -70,12 +75,12 @@ struct RSAPublicKey: CommonPublicKey {
 
     /// We return the ASN1 Encoded DER Representation of the public key because that's what the rawRepresentation of RSA SecKey return
     var rawRepresentation: Data {
-        let asnNodes: ASN1.Node = try! .sequence(nodes: [
+        let asnNodes: ASN1.Node = .sequence(nodes: [
             .sequence(nodes: [
                 .objectIdentifier(data: Data(RSAPublicKey.primaryObjectIdentifier)),
                 .null,
             ]),
-            .bitString(data: self.key.externalRepresentation()),
+            .bitString(data: externalRepresentationBytes),
         ])
 
         return Data(ASN1.Encoder.encode(asnNodes))
@@ -110,8 +115,13 @@ struct RSAPrivateKey: CommonPrivateKey {
     /// The underlying CryptoSwift RSA key that backs this struct
     private let key: RSA
 
-    fileprivate init(_ rsa: RSA) {
+    /// The PKCS#1 DER (`externalRepresentation()`) captured at init time so that the
+    /// non-throwing `rawRepresentation` accessor can never crash or silently return empty data.
+    private let externalRepresentationBytes: Data
+
+    fileprivate init(_ rsa: RSA) throws {
         self.key = rsa
+        self.externalRepresentationBytes = try rsa.externalRepresentation()
     }
 
     /// Initializes a new RSA key (backed by CryptoSwift) of the specified bit size
@@ -138,8 +148,11 @@ struct RSAPrivateKey: CommonPrivateKey {
 
     /// Expects the ASN1 Encoding of the DER formatted RSA Private Key
     init(rawRepresentation raw: Data) throws {
-        self.key = try RSA(rawRepresentation: raw)
-        guard self.key.d != nil else { throw NSError(domain: "Invalid Private Key", code: 0) }
+        let rsaKey = try RSA(rawRepresentation: raw)
+        guard rsaKey.d != nil else {
+            throw LibP2PCrypto.Keys.KeyError.invalidPrivateKeyEncoding("RSA: missing private exponent")
+        }
+        try self.init(rsaKey)
     }
 
     init(marshaledData data: Data) throws {
@@ -147,13 +160,14 @@ struct RSAPrivateKey: CommonPrivateKey {
     }
 
     var rawRepresentation: Data {
-        guard key.d != nil, let raw = try? self.key.externalRepresentation() else { return Data() }
-        return raw
+        externalRepresentationBytes
     }
 
     func derivePublicKey() throws -> CommonPublicKey {
-        guard key.d != nil else { throw NSError(domain: "Unable to extract public key", code: 0) }
-        return RSAPublicKey(CryptoSwift.RSA(n: key.n, e: key.e))
+        guard key.d != nil else {
+            throw LibP2PCrypto.Keys.KeyError.publicKeyDerivationFailed("RSA: no private exponent")
+        }
+        return try RSAPublicKey(CryptoSwift.RSA(n: key.n, e: key.e))
     }
 
     func decrypt(data: Data) throws -> Data {

--- a/Sources/LibP2PCrypto/Keys/Types/RSA/RSA+CryptoSwift.swift
+++ b/Sources/LibP2PCrypto/Keys/Types/RSA/RSA+CryptoSwift.swift
@@ -41,6 +41,7 @@ struct RSAPublicKey: CommonPublicKey {
             throw LibP2PCrypto.Keys.KeyError.invalidRawRepresentation("RSA public key: not an ASN.1 sequence")
         }
 
+        let rsaKey: RSA
         /// We have an objectID header....
         if case .sequence(let objectID) = params.first {
             guard case .objectIdentifier(let oid) = objectID.first else {
@@ -53,20 +54,15 @@ struct RSAPublicKey: CommonPublicKey {
                 throw LibP2PCrypto.Keys.KeyError.invalidRawRepresentation("RSA public key: missing key bit string")
             }
 
-            self.key = try CryptoSwift.RSA(rawRepresentation: bits)
-        } else if params.count == 2, case .integer = params.first {
+            rsaKey = try CryptoSwift.RSA(rawRepresentation: bits)
+        } else if params.count == 2, case .integer(let n) = params.first, case .integer(let e) = params.last {
             /// We have a direct sequence of integers
-            guard case .integer(let n) = params.first else {
-                throw NSError(domain: "Invalid ASN1 Encoding -> No Modulus", code: 0)
-            }
-            guard case .integer(let e) = params.last else {
-                throw NSError(domain: "Invalid ASN1 Encoding -> No Public Exponent", code: 0)
-            }
-
-            self.key = CryptoSwift.RSA(n: n.byteArray, e: e.byteArray)
+            rsaKey = CryptoSwift.RSA(n: n.byteArray, e: e.byteArray)
         } else {
             throw LibP2PCrypto.Keys.KeyError.invalidRawRepresentation("RSA public key: unrecognized structure")
         }
+
+        try self.init(rsaKey)
     }
 
     init(marshaledData data: Data) throws {
@@ -127,14 +123,9 @@ struct RSAPrivateKey: CommonPrivateKey {
     /// Initializes a new RSA key (backed by CryptoSwift) of the specified bit size
     internal init(keySize: Int) throws {
         switch keySize {
-        case 1024:
-            self.key = try CryptoSwift.RSA(keySize: keySize)
-        case 2048:
-            self.key = try CryptoSwift.RSA(keySize: keySize)
-        case 3072:
-            self.key = try CryptoSwift.RSA(keySize: keySize)
-        case 4096:
-            self.key = try CryptoSwift.RSA(keySize: keySize)
+        case 1024, 2048, 3072, 4096:
+            let rsaKey = try CryptoSwift.RSA(keySize: keySize)
+            try self.init(rsaKey)
         default:
             throw LibP2PCrypto.Keys.KeyError.invalidParameters(
                 "Invalid RSA key bit length (use 2048, 3072 or 4096), got \(keySize)"

--- a/Sources/LibP2PCrypto/Keys/Types/RSA/RSA+DER.swift
+++ b/Sources/LibP2PCrypto/Keys/Types/RSA/RSA+DER.swift
@@ -25,7 +25,7 @@ extension RSAPublicKey: DERCodable {
     }
 
     public func privateKeyDER() throws -> [UInt8] {
-        throw NSError(domain: "Public Key doesn't have private DER representation", code: 0)
+        throw LibP2PCrypto.Keys.KeyError.unsupportedOperation("A public key has no private DER representation")
     }
 
     init(publicDER: [UInt8]) throws {
@@ -33,7 +33,9 @@ extension RSAPublicKey: DERCodable {
     }
 
     init(privateDER: [UInt8]) throws {
-        throw NSError(domain: "Can't instantiate private key from public DER representation", code: 0)
+        throw LibP2PCrypto.Keys.KeyError.unsupportedOperation(
+            "Can't instantiate a public key from a private DER representation"
+        )
     }
 
     public func exportPublicKeyPEM(withHeaderAndFooter: Bool) throws -> [UInt8] {
@@ -69,7 +71,9 @@ extension RSAPrivateKey: DERCodable {
     }
 
     init(publicDER: [UInt8]) throws {
-        throw NSError(domain: "Can't instantiate private key from public DER representation", code: 0)
+        throw LibP2PCrypto.Keys.KeyError.unsupportedOperation(
+            "Can't instantiate a private key from a public DER representation"
+        )
     }
 
     init(privateDER: [UInt8]) throws {

--- a/Sources/LibP2PCrypto/Keys/Types/RSA/RSA+SecKey.swift
+++ b/Sources/LibP2PCrypto/Keys/Types/RSA/RSA+SecKey.swift
@@ -23,8 +23,13 @@ struct RSAPublicKey: CommonPublicKey {
     /// The underlying SecKey that backs this struct
     private let key: SecKey
 
-    fileprivate init(_ secKey: SecKey) {
+    /// The PKCS#1 DER (`SecKeyCopyExternalRepresentation`) captured at init time so that the
+    /// non-throwing `rawRepresentation` accessor can never crash or silently return empty data.
+    private let externalRepresentationBytes: Data
+
+    fileprivate init(_ secKey: SecKey) throws {
         self.key = secKey
+        self.externalRepresentationBytes = try secKey.rawRepresentation()
     }
 
     init(rawRepresentation raw: Data) throws {
@@ -40,7 +45,7 @@ struct RSAPublicKey: CommonPublicKey {
             throw LibP2PCrypto.Keys.KeyError.invalidRawRepresentation("RSA public key: \(error.debugDescription)")
         }
 
-        self.key = secKey
+        try self.init(secKey)
     }
 
     init(marshaledData data: Data) throws {
@@ -64,12 +69,12 @@ struct RSAPublicKey: CommonPublicKey {
     }
 
     var rawRepresentation: Data {
-        let asnNodes: ASN1.Node = try! .sequence(nodes: [
+        let asnNodes: ASN1.Node = .sequence(nodes: [
             .sequence(nodes: [
                 .objectIdentifier(data: Data(RSAPublicKey.primaryObjectIdentifier)),
                 .null,
             ]),
-            .bitString(data: self.key.rawRepresentation()),
+            .bitString(data: externalRepresentationBytes),
         ])
 
         return Data(ASN1.Encoder.encode(asnNodes))
@@ -119,8 +124,13 @@ struct RSAPrivateKey: CommonPrivateKey {
     /// The underlying SecKey that backs this struct
     private let key: SecKey
 
-    fileprivate init(_ secKey: SecKey) {
+    /// The PKCS#1 DER (`SecKeyCopyExternalRepresentation`) captured at init time so that the
+    /// non-throwing `rawRepresentation` accessor can never crash or silently return empty data.
+    private let externalRepresentationBytes: Data
+
+    fileprivate init(_ secKey: SecKey) throws {
         self.key = secKey
+        self.externalRepresentationBytes = try secKey.rawRepresentation()
     }
 
     /// Initializes a new RSA key (backed by SecKey) of the specified bit size
@@ -140,7 +150,7 @@ struct RSAPrivateKey: CommonPrivateKey {
             throw LibP2PCrypto.Keys.KeyError.keyGenerationFailed("RSA: \(error.debugDescription)")
         }
 
-        self.key = privKey
+        try self.init(privKey)
     }
 
     init(rawRepresentation raw: Data) throws {
@@ -156,7 +166,7 @@ struct RSAPrivateKey: CommonPrivateKey {
             throw LibP2PCrypto.Keys.KeyError.invalidRawRepresentation("RSA private key: \(error.debugDescription)")
         }
 
-        self.key = secKey
+        try self.init(secKey)
     }
 
     init(marshaledData data: Data) throws {
@@ -164,20 +174,14 @@ struct RSAPrivateKey: CommonPrivateKey {
     }
 
     var rawRepresentation: Data {
-        var error: Unmanaged<CFError>?
-        if let cfdata = SecKeyCopyExternalRepresentation(self.key, &error) {
-            return cfdata as Data
-        } else {
-            //throw NSError(domain: "RawKeyError: \(error.debugDescription)", code: 0, userInfo: nil)
-            return Data()
-        }
+        externalRepresentationBytes
     }
 
     func derivePublicKey() throws -> CommonPublicKey {
         guard let pubKey = SecKeyCopyPublicKey(self.key) else {
             throw LibP2PCrypto.Keys.KeyError.publicKeyDerivationFailed("RSA")
         }
-        return RSAPublicKey(pubKey)
+        return try RSAPublicKey(pubKey)
     }
 
     func decrypt(data: Data) throws -> Data {

--- a/Sources/LibP2PCrypto/Keys/Types/RSA/RSA+SecKey.swift
+++ b/Sources/LibP2PCrypto/Keys/Types/RSA/RSA+SecKey.swift
@@ -37,11 +37,7 @@ struct RSAPublicKey: CommonPublicKey {
 
         var error: Unmanaged<CFError>? = nil
         guard let secKey = SecKeyCreateWithData(raw as CFData, attributes as CFDictionary, &error) else {
-            throw NSError(
-                domain: "Error constructing SecKey from raw key data: \(error.debugDescription)",
-                code: 0,
-                userInfo: nil
-            )
+            throw LibP2PCrypto.Keys.KeyError.invalidRawRepresentation("RSA public key: \(error.debugDescription)")
         }
 
         self.key = secKey
@@ -49,20 +45,20 @@ struct RSAPublicKey: CommonPublicKey {
 
     init(marshaledData data: Data) throws {
         let asn = try ASN1.Decoder.decode(data: data)
-        guard case .sequence(let nodes) = asn else {
-            throw NSError(domain: "RSAPublicKey Invalid marshaled data", code: 0)
+        guard case .sequence(let nodes) = asn, nodes.count >= 2 else {
+            throw LibP2PCrypto.Keys.KeyError.invalidMarshaledData("RSA public key: expected a 2-element sequence")
         }
         guard case .sequence(let subjectInfo) = nodes[0] else {
-            throw NSError(domain: "RSAPublicKey Invalid marshaled data", code: 0)
+            throw LibP2PCrypto.Keys.KeyError.invalidMarshaledData("RSA public key: missing algorithm sequence")
         }
         guard case .objectIdentifier(let objID) = subjectInfo.first else {
-            throw NSError(domain: "RSAPublicKey Invalid marshaled data", code: 0)
+            throw LibP2PCrypto.Keys.KeyError.invalidMarshaledData("RSA public key: missing object identifier")
         }
         guard objID.byteArray == RSAPublicKey.primaryObjectIdentifier else {
-            throw NSError(domain: "RSAPublicKey Invalid marshaled data", code: 0)
+            throw LibP2PCrypto.Keys.KeyError.invalidMarshaledData("RSA public key: unexpected object identifier")
         }
         guard case .bitString(let bits) = nodes[1] else {
-            throw NSError(domain: "RSAPublicKey Invalid marshaled data", code: 0)
+            throw LibP2PCrypto.Keys.KeyError.invalidMarshaledData("RSA public key: missing key bit string")
         }
         try self.init(rawRepresentation: bits)
     }
@@ -83,7 +79,7 @@ struct RSAPublicKey: CommonPublicKey {
         var error: Unmanaged<CFError>?
         guard let encryptedData = SecKeyCreateEncryptedData(self.key, .rsaEncryptionPKCS1, data as CFData, &error)
         else {
-            throw NSError(domain: "Error Encrypting Data: \(error.debugDescription)", code: 0, userInfo: nil)
+            throw LibP2PCrypto.Keys.KeyError.encryptionFailed("RSA: \(error.debugDescription)")
         }
         return encryptedData as Data
     }
@@ -129,7 +125,9 @@ struct RSAPrivateKey: CommonPrivateKey {
 
     /// Initializes a new RSA key (backed by SecKey) of the specified bit size
     init(keySize: Int) throws {
-        guard keySize >= 1024 else { throw NSError(domain: "Invalid RSA Bit Size", code: 0) }
+        guard keySize >= 1024 else {
+            throw LibP2PCrypto.Keys.KeyError.invalidParameters("RSA bit size must be at least 1024, got \(keySize)")
+        }
 
         let parameters: [CFString: Any] = [
             kSecAttrKeyType: kSecAttrKeyTypeRSA,
@@ -139,8 +137,7 @@ struct RSAPrivateKey: CommonPrivateKey {
         var error: Unmanaged<CFError>? = nil
 
         guard let privKey = SecKeyCreateRandomKey(parameters as CFDictionary, &error) else {
-            print(error.debugDescription)
-            throw NSError(domain: "Key Generation Error: \(error.debugDescription)", code: 0, userInfo: nil)
+            throw LibP2PCrypto.Keys.KeyError.keyGenerationFailed("RSA: \(error.debugDescription)")
         }
 
         self.key = privKey
@@ -156,11 +153,7 @@ struct RSAPrivateKey: CommonPrivateKey {
 
         var error: Unmanaged<CFError>? = nil
         guard let secKey = SecKeyCreateWithData(raw as CFData, attributes as CFDictionary, &error) else {
-            throw NSError(
-                domain: "Error constructing SecKey from raw key data: \(error.debugDescription)",
-                code: 0,
-                userInfo: nil
-            )
+            throw LibP2PCrypto.Keys.KeyError.invalidRawRepresentation("RSA private key: \(error.debugDescription)")
         }
 
         self.key = secKey
@@ -182,7 +175,7 @@ struct RSAPrivateKey: CommonPrivateKey {
 
     func derivePublicKey() throws -> CommonPublicKey {
         guard let pubKey = SecKeyCopyPublicKey(self.key) else {
-            throw NSError(domain: "Public Key Extraction Error", code: 0, userInfo: nil)
+            throw LibP2PCrypto.Keys.KeyError.publicKeyDerivationFailed("RSA")
         }
         return RSAPublicKey(pubKey)
     }
@@ -191,7 +184,7 @@ struct RSAPrivateKey: CommonPrivateKey {
         var error: Unmanaged<CFError>?
         guard let decryptedData = SecKeyCreateDecryptedData(self.key, .rsaEncryptionPKCS1, data as CFData, &error)
         else {
-            throw NSError(domain: "Error Decrypting Data: \(error.debugDescription)", code: 0, userInfo: nil)
+            throw LibP2PCrypto.Keys.KeyError.decryptionFailed("RSA: \(error.debugDescription)")
         }
         return decryptedData as Data
     }
@@ -207,7 +200,7 @@ struct RSAPrivateKey: CommonPrivateKey {
                 message as CFData,
                 &error
             ) as Data?
-        else { throw NSError(domain: "Encountered NIL Signature Value", code: 0) }
+        else { throw LibP2PCrypto.Keys.KeyError.signatureFailed("RSA: encountered a nil signature value") }
 
         // Throw the error if we encountered one
         if let error = error { throw error.takeRetainedValue() as Error }
@@ -244,7 +237,7 @@ extension SecKey {
 
     func extractPubKey() throws -> SecKey {
         guard let pubKey = SecKeyCopyPublicKey(self) else {
-            throw NSError(domain: "Public Key Extraction Error", code: 0, userInfo: nil)
+            throw LibP2PCrypto.Keys.KeyError.publicKeyDerivationFailed("SecKey")
         }
         return pubKey
     }
@@ -256,7 +249,7 @@ extension SecKey {
         if let cfdata = SecKeyCopyExternalRepresentation(self, &error) {
             return cfdata as Data
         } else {
-            throw NSError(domain: "RawKeyError: \(error.debugDescription)", code: 0, userInfo: nil)
+            throw LibP2PCrypto.Keys.KeyError.invalidRawRepresentation("SecKey: \(error.debugDescription)")
         }
     }
 

--- a/Sources/LibP2PCrypto/Keys/Types/Secp256k1/Secp256k1.swift
+++ b/Sources/LibP2PCrypto/Keys/Types/Secp256k1/Secp256k1.swift
@@ -31,16 +31,12 @@ extension Secp256k1PublicKey: CommonPublicKey {
     }
 
     public func encrypt(data: Data) throws -> Data {
-        throw NSError(domain: "Secp256k1 Keys don't support encryption", code: 0)
+        throw LibP2PCrypto.Keys.KeyError.unsupportedOperation("Secp256k1 keys don't support encryption")
     }
 
     public func verify(signature: Data, for expectedData: Data) throws -> Bool {
         guard signature.count >= 32 + 32 + 1 else {
-            throw NSError(
-                domain: "Invalid Signature Length, expected at least 65 bytes, got \(signature.count)",
-                code: 0,
-                userInfo: nil
-            )
+            throw LibP2PCrypto.Keys.KeyError.invalidSignatureLength(expected: 65, got: signature.count)
         }
         let bytes = signature.byteArray
         let v: [UInt8] = [UInt8](bytes[0..<1])  //First byte
@@ -107,7 +103,7 @@ extension Secp256k1PrivateKey: CommonPrivateKey {
     }
 
     public func decrypt(data: Data) throws -> Data {
-        throw NSError(domain: "Secp256k1 Keys don't support decryption", code: 0)
+        throw LibP2PCrypto.Keys.KeyError.unsupportedOperation("Secp256k1 keys don't support decryption")
     }
 
     public func sign(message data: Data) throws -> Data {
@@ -134,7 +130,9 @@ extension Secp256k1PublicKey: DERCodable {
     }
 
     public convenience init(privateDER: [UInt8]) throws {
-        throw NSError(domain: "Can't instantiate private key from public DER representation", code: 0)
+        throw LibP2PCrypto.Keys.KeyError.unsupportedOperation(
+            "Can't instantiate a private key from a public DER representation"
+        )
     }
 
     public func publicKeyDER() throws -> [UInt8] {
@@ -142,7 +140,7 @@ extension Secp256k1PublicKey: DERCodable {
     }
 
     public func privateKeyDER() throws -> [UInt8] {
-        throw NSError(domain: "Public Key doesn't have private DER representation", code: 0)
+        throw LibP2PCrypto.Keys.KeyError.unsupportedOperation("A public key has no private DER representation")
     }
 
     public func exportPublicKeyPEM(withHeaderAndFooter: Bool) throws -> [UInt8] {
@@ -176,7 +174,9 @@ extension Secp256k1PrivateKey: DERCodable {
     public static var secondaryObjectIdentifier: [UInt8]? { nil }
 
     public convenience init(publicDER: [UInt8]) throws {
-        throw NSError(domain: "Can't instantiate private key from public DER representation", code: 0)
+        throw LibP2PCrypto.Keys.KeyError.unsupportedOperation(
+            "Can't instantiate a private key from a public DER representation"
+        )
     }
 
     public convenience init(privateDER: [UInt8]) throws {

--- a/Sources/LibP2PCrypto/Keys/Types/Secp256k1/Secp256k1PrivateKey.swift
+++ b/Sources/LibP2PCrypto/Keys/Types/Secp256k1/Secp256k1PrivateKey.swift
@@ -32,8 +32,12 @@ extension Array where Element == UInt8 {
     }
 }
 
-// TODO: Move to P256K implementation and remove @unchecked Sendable
-
+/// - Note: `@unchecked Sendable` is sound here because every stored property is a `let`:
+///   `rawPrivateKey` and `publicKey` are immutable, and the underlying `secp256k1_context`
+///   (`ctx`) is only ever used for signing / verification, which the secp256k1 library
+///   documents as thread-safe on a shared context (context randomization happens once, at
+///   creation). A future migration to the `swift-secp256k1` (P256K) package would let us drop
+///   `@unchecked` entirely.
 public final class Secp256k1PrivateKey: @unchecked Sendable {
 
     // MARK: - Properties

--- a/Sources/LibP2PCrypto/Keys/Types/Secp256k1/Secp256k1PrivateKey.swift
+++ b/Sources/LibP2PCrypto/Keys/Types/Secp256k1/Secp256k1PrivateKey.swift
@@ -140,6 +140,7 @@ public final class Secp256k1PrivateKey: @unchecked Sendable {
             free(pubKey)
         }
         var secret = privateKey
+        defer { Secp256k1PrivateKey.secureWipe(&secret) }
         if secp256k1_ec_pubkey_create(finalCtx, pubKey, &secret) != 1 {
             throw Error.pubKeyGenerationFailed
         }
@@ -246,6 +247,7 @@ public final class Secp256k1PrivateKey: @unchecked Sendable {
         }
 
         var seckey = rawPrivateKey
+        defer { Secp256k1PrivateKey.secureWipe(&seckey) }
 
         guard secp256k1_ecdsa_sign_recoverable(ctx, sig, &hash, &seckey, nil, nil) == 1 else {
             throw Error.internalError
@@ -278,9 +280,20 @@ public final class Secp256k1PrivateKey: @unchecked Sendable {
 
     private func verifyPrivateKey() throws {
         var secret = rawPrivateKey
+        defer { Secp256k1PrivateKey.secureWipe(&secret) }
         guard secp256k1_ec_seckey_verify(ctx, &secret) == 1 else {
             throw Error.keyMalformed
         }
+    }
+
+    /// Best-effort zeroing of a transient copy of secret key material.
+    ///
+    /// These copies exist only to satisfy the secp256k1 C API's non-`const` (`inout`) pointer
+    /// parameters; the library does not mutate the key. `@inline(never)` reduces the chance the
+    /// optimizer treats the final writes as a dead store and elides them.
+    @inline(never)
+    private static func secureWipe(_ bytes: inout [UInt8]) {
+        for i in bytes.indices { bytes[i] = 0 }
     }
 
     // MARK: - Errors

--- a/Sources/LibP2PCrypto/Keys/Types/Secp256k1/Secp256k1PublicKey.swift
+++ b/Sources/LibP2PCrypto/Keys/Types/Secp256k1/Secp256k1PublicKey.swift
@@ -38,8 +38,10 @@ public func secp256k1_default_ctx_destroy(ctx: OpaquePointer) {
     secp256k1_context_destroy(ctx)
 }
 
-// TODO: Move to P256K implementation and remove @unchecked Sendable
-
+/// - Note: `@unchecked Sendable` is sound here because every stored property is a `let`
+///   (`rawPublicKey`, `key`, and the `secp256k1_context` `ctx`, which is only used for the
+///   thread-safe parse / serialize / verify operations). A future migration to the
+///   `swift-secp256k1` (P256K) package would let us drop `@unchecked` entirely.
 public final class Secp256k1PublicKey: @unchecked Sendable {
 
     static let UNCOMPRESSED_LENGTH = 64

--- a/Sources/LibP2PCrypto/Keys/Types/Secp256k1/Secp256k1PublicKey.swift
+++ b/Sources/LibP2PCrypto/Keys/Types/Secp256k1/Secp256k1PublicKey.swift
@@ -110,7 +110,7 @@ public final class Secp256k1PublicKey: @unchecked Sendable {
         let res = secp256k1_ec_pubkey_parse(finalCtx, &pubKey, &rawPublicKeyData, rawPublicKeyData.count)
         // Check for parsing errors
         guard res == 1 else {
-            throw NSError(domain: "Secp256k1::ParsePublicKey::Unable to parse public key", code: 0)
+            throw Error.keyMalformed
         }
 
         // Attempt to serialize the pubkey in it's uncompressed form
@@ -125,7 +125,7 @@ public final class Secp256k1PublicKey: @unchecked Sendable {
         )
         // Check for serialization errors
         guard res2 == 1 else {
-            throw NSError(domain: "Secp256k1::ParsePublicKey::Unable to serialize uncompressed public key", code: 0)
+            throw Error.internalError
         }
 
         // Store the uncompressed public key in our rawPublicKey field
@@ -145,15 +145,12 @@ public final class Secp256k1PublicKey: @unchecked Sendable {
             UInt32(SECP256K1_EC_COMPRESSED)
         )
         guard res == 1 else {
-            throw NSError(domain: "Unable to uncompress pubkey", code: 0)
+            throw Error.internalError
         }
         guard compressedPubKey.count == pubKeyLength,
             compressedPubKey.count == Secp256k1PublicKey.COMPRESSED_LENGTH_WITH_HEADER
         else {
-            throw NSError(
-                domain: "Uncompressed Key Length Mismatch \(compressedPubKey.count) != \(pubKeyLength)",
-                code: 0
-            )
+            throw Error.internalError
         }
         return compressedPubKey
     }
@@ -199,7 +196,6 @@ public final class Secp256k1PublicKey: @unchecked Sendable {
 
         // Ensure the provided V value is valid
         guard let vInt = Int32(v.asString(base: .base16), radix: 16), vInt >= 0, vInt <= 3 else {
-            print("Invalid v param")
             throw Error.signatureMalformed
         }
 

--- a/Sources/LibP2PCrypto/LibP2PCrypto.swift
+++ b/Sources/LibP2PCrypto/LibP2PCrypto.swift
@@ -45,7 +45,7 @@ extension String {
     /// * algorithm = 'aes-128-gcm'
     public func encryptGCM(password: String) throws -> Data {
         guard let data = self.data(using: .utf8) else {
-            throw NSError(domain: "Failed to decode string into data", code: 0, userInfo: nil)
+            throw LibP2PCrypto.Keys.KeyError.invalidParameters("Failed to encode string into UTF-8 data")
         }
         return try data.encryptGCM(password: password)
     }
@@ -126,10 +126,8 @@ extension Array where Element == UInt8 {
         // Attempt to derive the aes encryption key from the password and salt
         // PBKDF2-SHA256
         guard let key = PBKDF2.SHA256(password: password, salt: Data(salt), keyByteCount: 16, rounds: 32767) else {
-            throw NSError(
-                domain: "Failed to derive AESGCM encryption key from plaintext password",
-                code: 0,
-                userInfo: nil
+            throw LibP2PCrypto.Keys.KeyError.encryptionFailed(
+                "Failed to derive AES-GCM encryption key from plaintext password"
             )
         }
 
@@ -150,10 +148,8 @@ extension Array where Element == UInt8 {
         // Attempt to derive the aes encryption key from the password and salt
         // PBKDF2-SHA256
         guard let key = PBKDF2.SHA256(password: password, salt: Data(salt), keyByteCount: 16, rounds: 32767) else {
-            throw NSError(
-                domain: "Failed to derive AESGCM encryption key from plaintext password",
-                code: 0,
-                userInfo: nil
+            throw LibP2PCrypto.Keys.KeyError.decryptionFailed(
+                "Failed to derive AES-GCM encryption key from plaintext password"
             )
         }
 

--- a/Sources/LibP2PCrypto/PEM/PEM+Encrypted.swift
+++ b/Sources/LibP2PCrypto/PEM/PEM+Encrypted.swift
@@ -19,6 +19,17 @@ import Foundation
 
 extension LibP2PCrypto.PEM {
 
+    /// Default PBKDF2 iteration count used when encrypting a new PEM.
+    ///
+    /// Raised from the legacy `2048` to follow modern guidance for PBKDF2. Decoding stays
+    /// parameter-driven (the iteration count is read from the PEM), so previously-encrypted
+    /// PEMs with any iteration count still import.
+    internal static let defaultPBKDF2Iterations = 310_000
+    /// Default PBKDF2 salt length in bytes used when encrypting a new PEM (raised from 8).
+    internal static let defaultPBKDF2SaltLength = 16
+    /// Default IV length in bytes for the default AES-128-CBC cipher.
+    internal static let defaultCipherIVLength = 16
+
     internal struct EncryptedPEM {
         let objectIdentifer: [UInt8]
         let ciphertext: [UInt8]
@@ -94,9 +105,17 @@ extension LibP2PCrypto.PEM {
     internal static func encryptPEM(
         _ pem: Data,
         withPassword password: String,
-        usingPBKDF pbkdf: PBKDFAlgorithm = .pbkdf2(salt: try! LibP2PCrypto.randomBytes(length: 8), iterations: 2048),
-        andCipher cipher: CipherAlgorithm = .aes_128_cbc(iv: try! LibP2PCrypto.randomBytes(length: 16))
+        usingPBKDF pbkdf: PBKDFAlgorithm? = nil,
+        andCipher cipher: CipherAlgorithm? = nil
     ) throws -> Data {
+
+        let cipher = try cipher ?? .aes_128_cbc(iv: LibP2PCrypto.randomBytes(length: defaultCipherIVLength))
+        let pbkdf =
+            try pbkdf
+            ?? .pbkdf2(
+                salt: LibP2PCrypto.randomBytes(length: defaultPBKDF2SaltLength),
+                iterations: defaultPBKDF2Iterations
+            )
 
         // Generate Encryption Key from Password
         let key = try pbkdf.deriveKey(password: password, ofLength: cipher.desiredKeyLength)
@@ -129,10 +148,13 @@ extension LibP2PCrypto.PEM {
     internal static func encryptPEMString(
         _ pem: Data,
         withPassword password: String,
-        usingPBKDF pbkdf: PBKDFAlgorithm = .pbkdf2(salt: try! LibP2PCrypto.randomBytes(length: 8), iterations: 2048),
-        andCipher cipher: CipherAlgorithm = .aes_128_cbc(iv: try! LibP2PCrypto.randomBytes(length: 16))
+        usingPBKDF pbkdf: PBKDFAlgorithm? = nil,
+        andCipher cipher: CipherAlgorithm? = nil
     ) throws -> String {
         let data = try LibP2PCrypto.PEM.encryptPEM(pem, withPassword: password, usingPBKDF: pbkdf, andCipher: cipher)
-        return String(data: data, encoding: .utf8)!
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw Error.encodingError
+        }
+        return string
     }
 }

--- a/Sources/LibP2PCrypto/PEM/PEM+PBKDF.swift
+++ b/Sources/LibP2PCrypto/PEM/PEM+PBKDF.swift
@@ -82,9 +82,22 @@ extension LibP2PCrypto.PEM {
                 .objectIdentifier(data: Data(self.objectIdentifier)),
                 .sequence(nodes: [
                     .octetString(data: Data(self.salt)),
-                    .integer(data: Data(self.iterations.bytes(totalBytes: 2))),
+                    .integer(data: Data(Self.encodeIterationCount(self.iterations))),
                 ]),
             ])
+        }
+
+        /// Encodes the PBKDF2 iteration count as the content octets of a DER `INTEGER`.
+        ///
+        /// The previous implementation hard-coded a 2-byte width, which silently truncated
+        /// iteration counts above 65535. This produces a minimal big-endian encoding and
+        /// prepends a `0x00` byte when the most significant bit is set so the value is never
+        /// misinterpreted as negative by strict DER parsers (e.g. OpenSSL).
+        static func encodeIterationCount(_ value: Int) -> [UInt8] {
+            var bytes = withUnsafeBytes(of: value.bigEndian, Array<UInt8>.init)
+            while bytes.count > 1, bytes.first == 0 { bytes.removeFirst() }
+            if let first = bytes.first, first & 0x80 != 0 { bytes.insert(0, at: 0) }
+            return bytes
         }
     }
 

--- a/Sources/LibP2PCrypto/PEM/PEM.swift
+++ b/Sources/LibP2PCrypto/PEM/PEM.swift
@@ -106,7 +106,6 @@ extension LibP2PCrypto {
                     self = .ecPrivateKey
 
                 default:
-                    print("Unsupported PEM Type: \(Data(bytes).toHexString())")
                     throw PEM.Error.unsupportedPEMType
                 }
             }

--- a/Tests/LibP2PCryptoTests/LibP2PCryptoTests.swift
+++ b/Tests/LibP2PCryptoTests/LibP2PCryptoTests.swift
@@ -730,9 +730,8 @@ struct SignAndVerifyTests {
         #expect(try secp.publicKey.verify(signature: signedData, for: message))
 
         var alertedSignedData = signedData
-        alertedSignedData[32] = 0
-        // We dont simply shuffle the data because it will most likely throw an error
-        // (due to invalid first byte 'v')
+        // Flip the final byte of `r` to a guaranteed-different (still in-range) value.
+        alertedSignedData[32] = alertedSignedData[32] == 0 ? 1 : 0
         #expect(try secp.publicKey.verify(signature: alertedSignedData, for: message) == false)
         // Invalid length will throw error...
         #expect(throws: Error.self) { try secp.publicKey.verify(signature: Data(signedData.dropFirst()), for: message) }

--- a/Tests/LibP2PCryptoTests/LibP2PCryptoTests.swift
+++ b/Tests/LibP2PCryptoTests/LibP2PCryptoTests.swift
@@ -21,6 +21,29 @@ import Testing
 
 @testable import LibP2PCrypto
 
+/// RSA key generation is prohibitively slow only in unoptimized (debug) builds that fall back to
+/// the CryptoSwift implementation (non-Apple platforms). On Apple platforms `SecKey` generation
+/// is fast even in debug, and release builds are fast everywhere, so RSA-generating tests only
+/// skip on debug + non-Apple.
+#if DEBUG && !canImport(Security)
+let runsRSAKeyGenTests = false
+#else
+let runsRSAKeyGenTests = true
+#endif
+
+let rsaTestsDisabledComment: Comment =
+    "RSA key generation is too slow in unoptimized CryptoSwift builds; run with `swift test -c release`."
+
+/// PBKDF2 key derivation at the production default (310k iterations) is slow in unoptimized
+/// builds, so the tests that actually derive a key use this smaller count in debug. The value has
+/// no effect on the encode/decode logic under test — only on how long derivation takes.
+#if DEBUG
+let testPBKDF2Iterations = 2_048
+#else
+let testPBKDF2Iterations = 310_000
+#endif
+
+
 /// Secp - https://techdocs.akamai.com/iot-token-access-control/docs/generate-ecdsa-keys
 /// JWT - https://techdocs.akamai.com/iot-token-access-control/docs/generate-jwt-ecdsa-keys
 /// Fixtures - http://cryptomanager.com/tv.html
@@ -61,7 +84,8 @@ struct Libp2pCryptoTests {
     }
 
     /// These tests are skipped on Linux when using CryptoSwift due to very slow key generation times.
-    @Test func testRSA3072() throws {
+    @Test(.enabled(if: runsRSAKeyGenTests, rsaTestsDisabledComment))
+    func testRSA3072() throws {
         let keyPair = try LibP2PCrypto.Keys.generateKeyPair(.RSA(bits: .B3072))
         print(keyPair)
         #expect(keyPair.keyType == .rsa)
@@ -75,7 +99,9 @@ struct Libp2pCryptoTests {
         #expect(attributes?.isPrivate == true)
     }
 
-    @Test func testRSA4096() throws {
+    /// These tests are skipped on Linux when using CryptoSwift due to very slow key generation times.
+    @Test(.enabled(if: runsRSAKeyGenTests, rsaTestsDisabledComment))
+    func testRSA4096() throws {
         let keyPair = try LibP2PCrypto.Keys.generateKeyPair(.RSA(bits: .B4096))
         print(keyPair)
         #expect(keyPair.keyType == .rsa)
@@ -1662,7 +1688,10 @@ struct DERAndPEMTests {
         #expect(keyPair.keyType == .rsa)
         #expect(keyPair.hasPrivateKey)
 
-        let exportedPEM = try keyPair.exportEncryptedPrivatePEMString(withPassword: "mypassword")
+        let exportedPEM = try keyPair.exportEncryptedPrivatePEMString(
+            withPassword: "mypassword",
+            usingPBKDF: .pbkdf2(salt: LibP2PCrypto.randomBytes(length: 16), iterations: testPBKDF2Iterations)
+        )
 
         let recoveredKey = try LibP2PCrypto.Keys.KeyPair(pem: exportedPEM, password: "mypassword")
 

--- a/Tests/LibP2PCryptoTests/LibP2PCryptoTests.swift
+++ b/Tests/LibP2PCryptoTests/LibP2PCryptoTests.swift
@@ -1814,3 +1814,218 @@ struct DERAndPEMTests {
         #expect(secp256k1Private.publicKey == secp256k1Public)
     }
 }
+
+/// Regression and enhancement coverage added alongside the bug-fix / modernization pass.
+///
+/// These tests focus on the gaps identified during review: public-only `KeyPair` guards
+/// (previously a force-unwrap crash), the newly-public sign/verify/marshal API, the
+/// modulus-derived `attributes()`, the raised encrypted-PEM defaults (and the PBKDF2
+/// iteration-encoding fix that made them safe), and malformed-input handling.
+@Suite("Regression Tests")
+struct RegressionTests {
+
+    /// Builds a public-only `KeyPair` by round-tripping the marshaled public key.
+    private func publicOnly(_ type: LibP2PCrypto.Keys.KeyPairType = .Ed25519) throws -> LibP2PCrypto.Keys.KeyPair {
+        let kp = try LibP2PCrypto.Keys.generateKeyPair(type)
+        return try LibP2PCrypto.Keys.KeyPair(marshaledPublicKey: kp.marshalPublicKey())
+    }
+
+    // MARK: - Public-only KeyPair guards
+
+    @Test func publicOnlyKeyPairReportsNoPrivateKey() throws {
+        let pub = try publicOnly()
+        #expect(pub.hasPrivateKey == false)
+        #expect(pub.privateKey == nil)
+    }
+
+    /// Regression: `exportEncryptedPrivatePEMString` used to force-unwrap `privateKey!` and crash.
+    @Test func exportEncryptedPrivatePEMOnPublicKeyThrowsInsteadOfCrashing() throws {
+        let pub = try publicOnly()
+        #expect(throws: LibP2PCrypto.Keys.KeyError.noPrivateKey) {
+            _ = try pub.exportEncryptedPrivatePEMString(withPassword: "hunter2")
+        }
+    }
+
+    @Test func privateOnlyOperationsThrowWithoutPrivateKey() throws {
+        let pub = try publicOnly()
+        let message = Data("libp2p".utf8)
+        #expect(throws: LibP2PCrypto.Keys.KeyError.noPrivateKey) { _ = try pub.sign(message: message) }
+        #expect(throws: LibP2PCrypto.Keys.KeyError.noPrivateKey) { _ = try pub.marshalPrivateKey() }
+        #expect(throws: LibP2PCrypto.Keys.KeyError.noPrivateKey) { _ = try pub.exportPrivatePEM() }
+        #expect(throws: LibP2PCrypto.Keys.KeyError.noPrivateKey) { _ = try pub.exportPrivatePEMString() }
+    }
+
+    // MARK: - Newly-public KeyPair API (fast key types; RSA is covered separately below)
+
+    @Test func keyPairSignAndVerifyRoundTrip() throws {
+        let message = Data("sign me".utf8)
+        for type: LibP2PCrypto.Keys.KeyPairType in [.Ed25519, .Secp256k1] {
+            let kp = try LibP2PCrypto.Keys.generateKeyPair(type)
+            let signature = try kp.sign(message: message)
+            #expect(try kp.verify(signature: signature, for: message))
+        }
+    }
+
+    @Test func marshalPrivateKeyRoundTrips() throws {
+        for type: LibP2PCrypto.Keys.KeyPairType in [.Ed25519, .Secp256k1] {
+            let kp = try LibP2PCrypto.Keys.generateKeyPair(type)
+            let marshaled = try kp.marshalPrivateKey()
+            #expect(marshaled.isEmpty == false)
+            let restored = try LibP2PCrypto.Keys.KeyPair(marshaledPrivateKey: marshaled)
+            #expect(restored.keyType == kp.keyType)
+            #expect(restored.privateKey != nil)
+            #expect(restored.publicKey.data == kp.publicKey.data)
+        }
+    }
+
+    // MARK: - RSA-specific coverage (skips only on debug + non-Apple, where keygen is slow)
+
+    @Test(.enabled(if: runsRSAKeyGenTests, rsaTestsDisabledComment))
+    func rsaSignVerifyAndMarshalPrivateKeyRoundTrip() throws {
+        let kp = try LibP2PCrypto.Keys.generateKeyPair(.RSA(bits: .B1024))
+
+        let message = Data("sign me".utf8)
+        let signature = try kp.sign(message: message)
+        #expect(try kp.verify(signature: signature, for: message))
+
+        let marshaled = try kp.marshalPrivateKey()
+        #expect(marshaled.isEmpty == false)
+        let restored = try LibP2PCrypto.Keys.KeyPair(marshaledPrivateKey: marshaled)
+        #expect(restored.keyType == kp.keyType)
+        #expect(restored.privateKey != nil)
+        #expect(restored.publicKey.data == kp.publicKey.data)
+    }
+
+    /// `attributes()` derives the RSA size from the modulus bit-length rather than a byte-count table.
+    @Test(.enabled(if: runsRSAKeyGenTests, rsaTestsDisabledComment))
+    func rsaAttributesReportModulusBitLength() throws {
+        for (type, expected) in [
+            (LibP2PCrypto.Keys.KeyPairType.RSA(bits: .B1024), 1024),
+            (LibP2PCrypto.Keys.KeyPairType.RSA(bits: .B2048), 2048),
+        ] {
+            let kp = try LibP2PCrypto.Keys.generateKeyPair(type)
+            #expect(kp.attributes()?.size == expected)
+            #expect(kp.attributes()?.isPrivate == true)
+        }
+    }
+
+    /// Regression: the SecKey/CryptoSwift RSA `rawRepresentation` used to either crash (`try!`)
+    /// or silently return empty `Data`. It must now be non-empty and round-trip.
+    @Test(.enabled(if: runsRSAKeyGenTests, rsaTestsDisabledComment))
+    func rsaRawRepresentationIsNonEmptyAndRoundTrips() throws {
+        let kp = try LibP2PCrypto.Keys.generateKeyPair(.RSA(bits: .B2048))
+        #expect(kp.publicKey.rawRepresentation.isEmpty == false)
+        let marshaled = try kp.marshalPrivateKey()
+        let restored = try LibP2PCrypto.Keys.KeyPair(marshaledPrivateKey: marshaled)
+        #expect(restored.publicKey.data == kp.publicKey.data)
+    }
+
+    // MARK: - Encrypted PEM: raised defaults and the iteration-encoding fix
+
+    /// Regression: `encodePBKDF()` previously encoded the iteration count in a fixed 2 bytes,
+    /// silently truncating any value above 65535. This exercises a genuinely large value; it only
+    /// encodes/decodes an ASN.1 integer, so it does no key derivation and is cheap in any build.
+    @Test func pbkdf2IterationEncodingSurvivesLargeValues() throws {
+        let salt = try LibP2PCrypto.randomBytes(length: 16)
+        let pbkdf = LibP2PCrypto.PEM.PBKDFAlgorithm.pbkdf2(salt: salt, iterations: 310_000)
+        let encoded = ASN1.Encoder.encode(try pbkdf.encodePBKDF())
+        let decoded = try LibP2PCrypto.PEM.decodePBKFD(ASN1.Decoder.decode(data: Data(encoded)))
+        #expect(decoded.iterations == 310_000)
+        #expect(decoded.salt == salt)
+    }
+
+    /// The production defaults must stay strong regardless of build configuration. The cheap
+    /// constant checks run everywhere; the full-strength derivation (slow in debug) only in release.
+    @Test func defaultPBKDF2ParametersAreStrong() throws {
+        #expect(LibP2PCrypto.PEM.defaultPBKDF2Iterations >= 310_000)
+        #expect(LibP2PCrypto.PEM.defaultPBKDF2SaltLength >= 16)
+
+        #if !DEBUG
+        let kp = try LibP2PCrypto.Keys.generateKeyPair(.Ed25519)
+        let pemString = try kp.exportEncryptedPrivatePEMString(withPassword: "pw")
+        let (type, bytes, _) = try LibP2PCrypto.PEM.pemToData(Array(pemString.utf8))
+        #expect(type == .encryptedPrivateKey)
+        let decoded = try LibP2PCrypto.PEM.decodeEncryptedPEM(Data(bytes))
+        #expect(decoded.pbkdfAlgorithm.iterations == LibP2PCrypto.PEM.defaultPBKDF2Iterations)
+        #expect(decoded.pbkdfAlgorithm.salt.count == LibP2PCrypto.PEM.defaultPBKDF2SaltLength)
+        #endif
+    }
+
+    @Test func encryptedPEMRoundTripsForFastKeyTypes() throws {
+        let password = "correct horse battery staple"
+        for type: LibP2PCrypto.Keys.KeyPairType in [.Ed25519, .Secp256k1] {
+            let kp = try LibP2PCrypto.Keys.generateKeyPair(type)
+            let pemBytes = try kp.exportEncryptedPrivatePEM(
+                withPassword: password,
+                usingPBKDF: .pbkdf2(salt: LibP2PCrypto.randomBytes(length: 16), iterations: testPBKDF2Iterations)
+            )
+            let restored = try LibP2PCrypto.Keys.KeyPair(pem: pemBytes, password: password)
+            #expect(restored.keyType == kp.keyType)
+            #expect(restored.publicKey.data == kp.publicKey.data)
+        }
+    }
+
+    @Test func encryptedPEMWithAES256CBCRoundTrips() throws {
+        let kp = try LibP2PCrypto.Keys.generateKeyPair(.Ed25519)
+        let password = "pw"
+        let pemBytes = try kp.exportEncryptedPrivatePEM(
+            withPassword: password,
+            usingPBKDF: .pbkdf2(salt: LibP2PCrypto.randomBytes(length: 16), iterations: testPBKDF2Iterations),
+            andCipher: .aes_256_cbc(iv: LibP2PCrypto.randomBytes(length: 16))
+        )
+        let restored = try LibP2PCrypto.Keys.KeyPair(pem: pemBytes, password: password)
+        #expect(restored.publicKey.data == kp.publicKey.data)
+    }
+
+    @Test func decryptingEncryptedPEMWithWrongPasswordFails() throws {
+        let kp = try LibP2PCrypto.Keys.generateKeyPair(.Ed25519)
+        let pemBytes = try kp.exportEncryptedPrivatePEM(
+            withPassword: "right",
+            usingPBKDF: .pbkdf2(salt: LibP2PCrypto.randomBytes(length: 16), iterations: testPBKDF2Iterations)
+        )
+        #expect(throws: (any Error).self) {
+            _ = try LibP2PCrypto.Keys.KeyPair(pem: pemBytes, password: "wrong")
+        }
+    }
+
+    // MARK: - Malformed input handling
+
+    @Test func malformedPEMThrows() {
+        let junk = "-----BEGIN PUBLIC KEY-----\nnot valid base64 @@@\n-----END PUBLIC KEY-----"
+        #expect(throws: (any Error).self) {
+            _ = try LibP2PCrypto.Keys.KeyPair(pem: junk)
+        }
+    }
+
+    @Test func malformedMarshaledKeysThrow() {
+        #expect(throws: (any Error).self) {
+            _ = try LibP2PCrypto.Keys.KeyPair(marshaledPublicKey: Data([0x01, 0x02, 0x03]))
+        }
+        #expect(throws: (any Error).self) {
+            _ = try LibP2PCrypto.Keys.KeyPair(marshaledPrivateKey: Data([0x01, 0x02, 0x03]))
+        }
+    }
+
+    @Test func truncatedASN1SequenceThrows() {
+        // Tag 0x30 (SEQUENCE) declares 5 content bytes but supplies none.
+        #expect(throws: (any Error).self) {
+            _ = try ASN1.Decoder.decode(data: Data([0x30, 0x05]))
+        }
+    }
+
+    @Test func shortSecp256k1SignatureThrowsInvalidLength() throws {
+        let kp = try LibP2PCrypto.Keys.generateKeyPair(.Secp256k1)
+        #expect(throws: (any Error).self) {
+            _ = try kp.verify(signature: Data([0x00, 0x01, 0x02]), for: Data("msg".utf8))
+        }
+    }
+
+    // MARK: - Async key generation
+
+    @Test func asyncKeyGenerationProducesUsableKeyPair() async throws {
+        let kp = try await LibP2PCrypto.Keys.generateKeyPair(.Ed25519)
+        let message = Data("async".utf8)
+        let signature = try kp.sign(message: message)
+        #expect(try kp.verify(signature: signature, for: message))
+    }
+}

--- a/Tests/LibP2PCryptoTests/LibP2PCryptoTests.swift
+++ b/Tests/LibP2PCryptoTests/LibP2PCryptoTests.swift
@@ -43,7 +43,6 @@ let testPBKDF2Iterations = 2_048
 let testPBKDF2Iterations = 310_000
 #endif
 
-
 /// Secp - https://techdocs.akamai.com/iot-token-access-control/docs/generate-ecdsa-keys
 /// JWT - https://techdocs.akamai.com/iot-token-access-control/docs/generate-jwt-ecdsa-keys
 /// Fixtures - http://cryptomanager.com/tv.html


### PR DESCRIPTION
### What?
- Replaced all `NSError`s with proper typed `Swift.Error`s
- Made key pair operations public (they were internal) sign, verify, encrypt, decrypt
- bumped the standard pbkdf params (stronger encrypted PEM files by default)
- clear out SecP256k1 keys before deallocating
- additional tests with debug and non apple platform flags to speed up tests