### PR TITLE
Misc Fixes

### DIFF
--- a/Sources/LibP2PCrypto/Keys/CommonPublicKey.swift
+++ b/Sources/LibP2PCrypto/Keys/CommonPublicKey.swift
@@ -54,12 +54,20 @@ public protocol CommonPublicKey: DERCodable, Sendable {
 extension CommonPublicKey {
     var keyType: LibP2PCrypto.Keys.GenericKeyType { Self.keyType }
 
+    /// The multihash of the marshaled public key, per the libp2p peer-id spec.
+    ///
+    /// Keys whose marshaled (protobuf) form is 42 bytes or smaller are inlined verbatim using the
+    /// `identity` multihash; larger keys are condensed with `sha2-256`. This is a size rule, not a
+    /// per-key-type rule, and mirrors go-libp2p's `maxInlineKeyLength` behavior. In practice
+    /// Ed25519 (~36 bytes) and Secp256k1 (~37 bytes) keys are inlined while RSA keys are hashed.
+    ///
+    /// - Reference: https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md
     public func multihash() throws -> Multihash {
-        switch self.keyType {
-        case .ed25519:
-            return try Multihash(raw: self.marshal(), hashedWith: .identity)
-        default:
-            return try Multihash(raw: self.marshal(), hashedWith: .sha2_256)
+        let marshaled = try self.marshal()
+        if marshaled.count <= 42 {
+            return try Multihash(raw: marshaled, hashedWith: .identity)
+        } else {
+            return try Multihash(raw: marshaled, hashedWith: .sha2_256)
         }
     }
 

--- a/Sources/LibP2PCrypto/Keys/KeyPair.swift
+++ b/Sources/LibP2PCrypto/Keys/KeyPair.swift
@@ -433,6 +433,8 @@ extension LibP2PCrypto.Keys.KeyPair {
         try publicKey.exportPublicKeyPEM(withHeaderAndFooter: withHeaderAndFooter)
     }
 
+    /// - Warning:
+    /// Exporting unencrypted private keys is usually a bad idea. Use `exportEncryptedPrivatePEM(withPassword:String)` instead when possible.
     public func exportPrivatePEM(withHeaderAndFooter: Bool = true) throws -> [UInt8] {
         guard let privKey = self.privateKey else {
             throw LibP2PCrypto.Keys.KeyError.noPrivateKey
@@ -445,6 +447,8 @@ extension LibP2PCrypto.Keys.KeyPair {
         try publicKey.exportPublicKeyPEMString(withHeaderAndFooter: withHeaderAndFooter)
     }
 
+    /// - Warning:
+    /// Exporting unencrypted private keys is usually a bad idea. Use `exportEncryptedPrivatePEMString(withPassword:String)` instead when possible.
     public func exportPrivatePEMString(withHeaderAndFooter: Bool = true) throws -> String {
         guard let privKey = self.privateKey else {
             throw LibP2PCrypto.Keys.KeyError.noPrivateKey
@@ -452,11 +456,7 @@ extension LibP2PCrypto.Keys.KeyPair {
         return try privKey.exportPrivateKeyPEMString(withHeaderAndFooter: withHeaderAndFooter)
     }
 
-    public func exportEncryptedPrivatePEMString(withPassword password: String) throws -> String {
-        try self.exportEncryptedPrivatePEMString(withPassword: password, usingPBKDF: nil, andCipher: nil)
-    }
-
-    internal func exportEncryptedPrivatePEM(
+    public func exportEncryptedPrivatePEM(
         withPassword password: String,
         usingPBKDF pbkdf: LibP2PCrypto.PEM.PBKDFAlgorithm? = nil,
         andCipher cipher: LibP2PCrypto.PEM.CipherAlgorithm? = nil
@@ -473,7 +473,7 @@ extension LibP2PCrypto.Keys.KeyPair {
         ).byteArray
     }
 
-    internal func exportEncryptedPrivatePEMString(
+    public func exportEncryptedPrivatePEMString(
         withPassword password: String,
         usingPBKDF pbkdf: LibP2PCrypto.PEM.PBKDFAlgorithm? = nil,
         andCipher cipher: LibP2PCrypto.PEM.CipherAlgorithm? = nil

--- a/Sources/LibP2PCrypto/PEM/PEM+Cipher.swift
+++ b/Sources/LibP2PCrypto/PEM/PEM+Cipher.swift
@@ -19,22 +19,31 @@ import Foundation
 
 extension LibP2PCrypto.PEM {
     // MARK: Add support for new Cipher Algorithms here...
-    internal enum CipherAlgorithm {
+    public enum CipherAlgorithm {
         case aes_128_cbc(iv: [UInt8])
         case aes_256_cbc(iv: [UInt8])
         //case des3(iv: [UInt8])
 
         init(objID: [UInt8], iv: [UInt8]) throws {
+            let algorithm: CipherAlgorithm
             switch objID {
             case [0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x01, 0x02]:  // aes-128-cbc
-                self = .aes_128_cbc(iv: iv)
+                algorithm = .aes_128_cbc(iv: iv)
             case [0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x01, 0x2a]:  // aes-256-cbc
-                self = .aes_256_cbc(iv: iv)
+                algorithm = .aes_256_cbc(iv: iv)
             //case [42, 134, 72, 134, 247, 13, 3, 7]:
-            //  self = .des3(iv: iv)
+            //  algorithm = .des3(iv: iv)
             default:
                 throw Error.unsupportedCipherAlgorithm(objID)
             }
+            // Validate the IV length up front so a malformed PEM fails here with a clear
+            // error rather than deep inside CryptoSwift's CBC block-mode at decrypt time.
+            guard iv.count == algorithm.expectedIVLength else {
+                throw Error.invalidPEMFormat(
+                    "EncryptedPrivateKey::CIPHER::IV length \(iv.count), expected \(algorithm.expectedIVLength)"
+                )
+            }
+            self = algorithm
         }
 
         func decrypt(bytes: [UInt8], withKey key: [UInt8]) throws -> [UInt8] {
@@ -65,6 +74,14 @@ extension LibP2PCrypto.PEM {
             switch self {
             case .aes_128_cbc: return 16
             case .aes_256_cbc: return 32
+            }
+        }
+
+        /// The initialization-vector length required by this Cipher strategy.
+        /// - Note: AES-CBC uses a 16-byte IV (one AES block) for both the 128- and 256-bit key sizes.
+        var expectedIVLength: Int {
+            switch self {
+            case .aes_128_cbc, .aes_256_cbc: return 16
             }
         }
 

--- a/Sources/LibP2PCrypto/PEM/PEM+PBKDF.swift
+++ b/Sources/LibP2PCrypto/PEM/PEM+PBKDF.swift
@@ -17,14 +17,37 @@ import Foundation
 
 // MARK: Encrypted PEM PBKDF Algorithms
 
+extension LibP2PCrypto {
+    public static func random8ByteSalt() throws -> [UInt8] {
+        try LibP2PCrypto.randomBytes(length: 8)
+    }
+
+    public static func random16ByteSalt() throws -> [UInt8] {
+        try LibP2PCrypto.randomBytes(length: 16)
+    }
+}
+
 extension LibP2PCrypto.PEM {
     // MARK: Add support for new PBKDF Algorithms here...
-    internal enum PBKDFAlgorithm {
+    public enum PBKDFAlgorithm {
+        /// - Note:
+        /// Salt is usually 8 or 16 bytes of secure random bytes (consider using `LibP2PCrypto.randomBytes()`)
+        /// - Note:
+        /// Iterations *should* be in the 100's of thousands (the default is 310_000) lower values are less secure, but faster to compute.
         case pbkdf2(salt: [UInt8], iterations: Int)
+
+        /// Minimum accepted salt length in bytes (PKCS#5 / RFC 8018 recommend at least 64 bits).
+        /// Kept at 8 so previously-encrypted PEMs (whose legacy default salt was 8 bytes) still import.
+        static let minimumSaltLength = 8
 
         init(objID: [UInt8], salt: [UInt8], iterations: [UInt8]) throws {
             guard let iterations = Int(iterations.toHexString(), radix: 16) else {
                 throw Error.invalidPEMFormat("EncryptedPrivateKey::PBKDF")
+            }
+            guard salt.count >= Self.minimumSaltLength else {
+                throw Error.invalidPEMFormat(
+                    "EncryptedPrivateKey::PBKDF::salt too short (\(salt.count) < \(Self.minimumSaltLength))"
+                )
             }
             switch objID {
             case [42, 134, 72, 134, 247, 13, 1, 5, 12]:  // pbkdf2


### PR DESCRIPTION
### What?
- Inline public keys who's marshaled values are less than 42 bytes in length (Ed25519 and Secp256k1)
- Exposed Cipher and PBKDF so consumers can alter the strength of their encrypted PEM exports